### PR TITLE
core: refactor API to support all structures

### DIFF
--- a/include/ctraces/ctr_link.h
+++ b/include/ctraces/ctr_link.h
@@ -1,0 +1,48 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CTR_LINK_H
+#define CTR_LINK_H
+
+#include <ctraces/ctraces.h>
+
+struct ctrace_link {
+	struct ctrace_id *trace_id;       /* the unique traceID    */
+    struct ctrace_id *span_id;        /* the unique span ID    */
+	cfl_sds_t trace_state;            /* trace_state           */
+    struct ctrace_attributes *attr;   /* attributes */
+    uint32_t dropped_attr_count;      /* number of attributes that were discarded */
+    struct cfl_list _head;            /* link to 'struct span->links' list */
+};
+
+struct ctrace_link *ctr_link_create(struct ctrace_span *span,
+                                    void *trace_id_buf, size_t trace_id_len,
+                                    void *span_id_buf, size_t span_id_len);
+
+struct ctrace_link *ctr_link_create_with_cid(struct ctrace_span *span,
+                                             struct ctrace_id *trace_id_cid,
+					 					     struct ctrace_id *span_id_cid);
+
+int ctr_link_set_trace_state(struct ctrace_link *link, char *trace_state);
+int ctr_link_set_attributes(struct ctrace_link *link, struct ctrace_attributes *attr);
+void ctr_link_set_dropped_attr_count(struct ctrace_link *link, uint32_t count);
+
+void ctr_link_destroy(struct ctrace_link *link);
+
+#endif

--- a/include/ctraces/ctr_resource.h
+++ b/include/ctraces/ctr_resource.h
@@ -25,15 +25,26 @@
 struct ctrace_resource {
     uint32_t dropped_attr_count;      /* number of attributes that were discarded */
     struct ctrace_attributes *attr;   /* attributes */
-    cfl_sds_t schema_url;             /* schema_url */
-    struct cfl_list _head;            /* link to struct ctrace->resources list */
 };
 
-struct ctrace_resource *ctr_resource_create(struct ctrace *ctx);
-struct ctrace_resource *ctr_resource_create_default(struct ctrace *ctx);
-int ctr_resource_set_schema_url(struct ctrace_resource *res, char *url);
+struct ctrace_resource_span {
+    struct ctrace_resource *resource;
+    struct cfl_list scope_spans;
+    cfl_sds_t schema_url;
+    struct cfl_list _head;               /* link to ctraces->resource_span list */
+};
+
+/* resource */
+struct ctrace_resource *ctr_resource_create();
+struct ctrace_resource *ctr_resource_create_default();
 int ctr_resource_set_attributes(struct ctrace_resource *res, struct ctrace_attributes *attr);
-void ctr_resource_set_dropped_attr_count(struct ctrace_resource *res, int count);
+void ctr_resource_set_dropped_attr_count(struct ctrace_resource *res, uint32_t count);
 void ctr_resource_destroy(struct ctrace_resource *res);
+
+/* resource_span */
+struct ctrace_resource_span *ctr_resource_span_create(struct ctrace *ctx);
+int ctr_resource_span_set_schema_url(struct ctrace_resource_span *resource_span, char *url);
+void ctr_resource_span_set_resource(struct ctrace_resource_span *resource_span, struct ctrace_resource *resource);
+void ctr_resource_span_destroy(struct ctrace_resource_span *resource_span);
 
 #endif

--- a/include/ctraces/ctr_resource.h
+++ b/include/ctraces/ctr_resource.h
@@ -25,12 +25,14 @@
 struct ctrace_resource {
     uint32_t dropped_attr_count;      /* number of attributes that were discarded */
     struct ctrace_attributes *attr;   /* attributes */
+    cfl_sds_t schema_url;             /* schema_url */
     struct cfl_list _head;            /* link to struct ctrace->resources list */
 };
 
 struct ctrace_resource *ctr_resource_create(struct ctrace *ctx);
 struct ctrace_resource *ctr_resource_create_default(struct ctrace *ctx);
-int ctr_resources_set_attributes(struct ctrace_resource *res, struct ctrace_attributes *attr);
+int ctr_resource_set_schema_url(struct ctrace_resource *res, char *url);
+int ctr_resource_set_attributes(struct ctrace_resource *res, struct ctrace_attributes *attr);
 void ctr_resource_set_dropped_attr_count(struct ctrace_resource *res, int count);
 void ctr_resource_destroy(struct ctrace_resource *res);
 

--- a/include/ctraces/ctr_scope.h
+++ b/include/ctraces/ctr_scope.h
@@ -1,0 +1,53 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CTR_SCOPE_SPAN_H
+#define CTR_SCOPE_SPAN_H
+
+#include <ctraces/ctraces.h>
+#include <ctraces/ctr_resource.h>
+
+struct ctrace_instrumentation_scope {
+    cfl_sds_t name;
+    cfl_sds_t version;
+    uint32_t dropped_attr_count;      /* number of attributes that were discarded */
+    struct ctrace_attributes *attr;   /* attributes */
+};
+
+struct ctrace_scope_span {
+    struct ctrace_instrumentation_scope *instrumentation_scope;
+    struct cfl_list spans;
+    cfl_sds_t schema_url;
+    struct cfl_list _head;           /* link to ctrace_resource_span->scope_spans list */
+};
+
+/* scope span */
+struct ctrace_scope_span *ctr_scope_span_create(struct ctrace_resource_span *resource_span);
+void ctr_scope_span_destroy(struct ctrace_scope_span *scope_span);
+int ctr_scope_span_set_schema_url(struct ctrace_scope_span *scope_span, char *url);
+void ctr_scope_span_set_instrumentation_scope(struct ctrace_scope_span *scope_span, struct ctrace_instrumentation_scope *ins_scope);
+
+/* instrumentation scope */
+struct ctrace_instrumentation_scope *ctr_instrumentation_scope_create(char *name, char *version,
+                                                                      uint32_t dropped_attr_count,
+                                                                      struct ctrace_attributes *attr);
+void ctr_instrumentation_scope_destroy(struct ctrace_instrumentation_scope *ins_scope);
+
+#endif
+

--- a/include/ctraces/ctr_span.h
+++ b/include/ctraces/ctr_span.h
@@ -64,9 +64,11 @@ struct ctrace_span_event {
     struct cfl_list _head;
 };
 
+/* Scope Spans */
 /* span context */
 struct ctrace_span {
-    struct ctrace_id *id;             /* the unique span ID    */
+    struct ctrace_id *trace_id;       /* the unique span ID    */
+    struct ctrace_id *span_id;        /* the unique span ID    */
     struct ctrace_id *parent_span_id; /* any parent ?, id=0 means a root span */
 
     int kind;                         /* span kind */
@@ -100,10 +102,12 @@ int ctr_span_set_status(struct ctrace_span *span, int code, char *message);
 void ctr_span_set_dropped_events_count(struct ctrace_span *span, int n);
 
 /* span IDs */
-int ctr_span_set_id(struct ctrace_span *span, void *buf, size_t len);
-int ctr_span_set_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid);
-int ctr_span_set_parent_id(struct ctrace_span *span, void *buf, size_t len);
-int ctr_span_set_parent_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid);
+int ctr_span_set_trace_id(struct ctrace_span *span, void *buf, size_t len);
+int ctr_span_set_trace_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid);
+int ctr_span_set_span_id(struct ctrace_span *span, void *buf, size_t len);
+int ctr_span_set_span_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid);
+int ctr_span_set_parent_span_id(struct ctrace_span *span, void *buf, size_t len);
+int ctr_span_set_parent_span_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid);
 
 /* resource scope */
 void ctr_span_set_resource(struct ctrace_span *span, struct ctrace_resource *res);

--- a/include/ctraces/ctraces.h
+++ b/include/ctraces/ctraces.h
@@ -26,27 +26,14 @@
 /* local libs */
 #include <cfl/cfl.h>
 
-/* headers that are needed in general */
-#include <ctraces/ctr_info.h>
-#include <ctraces/ctr_id.h>
-#include <ctraces/ctr_random.h>
-#include <ctraces/ctr_version.h>
-#include <ctraces/ctr_span.h>
-#include <ctraces/ctr_resource.h>
-#include <ctraces/ctr_attributes.h>
-#include <ctraces/ctr_log.h>
-
-/* encoders */
-#include <ctraces/ctr_encode_text.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 
 /* ctrace options creation keys */
 #define CTR_OPTS_TRACE_ID   0
 
+/* options is unused for now */
 struct ctrace_opts {
-    cfl_sds_t  trace_id;
 };
 
 struct ctrace {
@@ -55,14 +42,20 @@ struct ctrace {
      * a new span is created this value gets incremented.
      */
     uint64_t last_span_id;
-    struct cfl_list spans;
-
 
     /*
      * When the user creates a new resource, we add it to a linked list so on
      * every span we just keep a reference.
      */
-    struct cfl_list resources;
+    struct cfl_list resource_spans;
+
+    /*
+     * This 'span_list' is used for internal purposes only when a caller needs to
+     * iterate all spans linearly without getting inside a loop with resource_span, scope_spans, etc.
+     *
+     * note: every 'span' is linked to a 'scope_span' and to 'span_list' (this structure)
+     */
+    struct cfl_list span_list;
 
     /* logging */
     int log_level;
@@ -76,5 +69,21 @@ void ctr_destroy(struct ctrace *ctx);
 void ctr_opts_init(struct ctrace_opts *opts);
 void ctr_opts_set(struct ctrace_opts *opts, int value, char *val);
 void ctr_opts_exit(struct ctrace_opts *opts);
+
+/* headers that are needed in general */
+#include <ctraces/ctr_info.h>
+#include <ctraces/ctr_id.h>
+#include <ctraces/ctr_random.h>
+#include <ctraces/ctr_version.h>
+#include <ctraces/ctr_span.h>
+#include <ctraces/ctr_scope.h>
+#include <ctraces/ctr_link.h>
+#include <ctraces/ctr_attributes.h>
+#include <ctraces/ctr_log.h>
+#include <ctraces/ctr_resource.h>
+
+/* encoders */
+#include <ctraces/ctr_encode_text.h>
+
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ set(src
   ctraces.c
   ctr_resource.c
   ctr_span.c
+  ctr_link.c
+  ctr_scope.c
   ctr_log.c
   ctr_id.c
   ctr_random.c

--- a/src/ctr_link.c
+++ b/src/ctr_link.c
@@ -1,0 +1,142 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <ctraces/ctraces.h>
+
+struct ctrace_link *ctr_link_create(struct ctrace_span *span,
+                                    void *trace_id_buf, size_t trace_id_len,
+                                    void *span_id_buf, size_t span_id_len)
+{
+    struct ctrace_link *link;
+
+    link = calloc(1, sizeof(struct ctrace_link));
+    if (!link) {
+        ctr_errno();
+        return NULL;
+    }
+
+    /* trace_id */
+    if (trace_id_buf && trace_id_len > 0) {
+        link->trace_id = ctr_id_create(trace_id_buf, trace_id_len);
+        if (!link->trace_id) {
+            free(link);
+            return NULL;
+        }
+    }
+
+    /* span_id */
+    if (span_id_buf && span_id_len > 0) {
+        link->span_id = ctr_id_create(span_id_buf, span_id_len);
+        if (!link->span_id) {
+            ctr_id_destroy(link->trace_id);
+            free(link);
+            return NULL;
+        }
+    }
+
+    cfl_list_add(&link->_head, &span->links);
+    return link;
+}
+
+struct ctrace_link *ctr_link_create_with_cid(struct ctrace_span *span,
+                                             struct ctrace_id *trace_id_cid,
+                                             struct ctrace_id *span_id_cid)
+{
+    size_t trace_id_len = 0;
+    size_t span_id_len = 0;
+    void *trace_id_buf = NULL;
+    void *span_id_buf = NULL;
+
+    if (trace_id_cid) {
+        trace_id_buf = ctr_id_get_buf(trace_id_cid);
+        trace_id_len = ctr_id_get_len(trace_id_cid);
+    }
+
+    if (span_id_cid) {
+        span_id_buf = ctr_id_get_buf(span_id_cid);
+        span_id_len = ctr_id_get_len(span_id_cid);
+    }
+
+    return ctr_link_create(span, trace_id_buf, trace_id_len, span_id_buf, span_id_len);
+}
+
+int ctr_link_set_trace_state(struct ctrace_link *link, char *trace_state)
+{
+    if (!link || !trace_state) {
+        return -1;
+    }
+
+    link->trace_state = cfl_sds_create(trace_state);
+    if (!link->trace_state) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int ctr_link_set_attributes(struct ctrace_link *link, struct ctrace_attributes *attr)
+{
+    if (!attr) {
+        return -1;
+    }
+
+    link->attr = attr;
+    return 0;
+}
+
+void ctr_link_set_dropped_attr_count(struct ctrace_link *link, uint32_t count)
+{
+    link->dropped_attr_count = count;
+}
+
+void ctr_link_destroy(struct ctrace_link *link)
+{
+    if (link->trace_id) {
+        ctr_id_destroy(link->trace_id);
+    }
+
+    if (link->span_id) {
+        ctr_id_destroy(link->span_id);
+    }
+
+    if (link->trace_state) {
+        cfl_sds_destroy(link->trace_state);
+    }
+
+    if (link->attr) {
+        ctr_attributes_destroy(link->attr);
+    }
+
+    cfl_list_del(&link->_head);
+    free(link);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/ctr_resource.c
+++ b/src/ctr_resource.c
@@ -54,11 +54,25 @@ struct ctrace_resource *ctr_resource_create_default(struct ctrace *ctx)
     ctr_attributes_set_string(attr, "service.name", "Fluent Bit");
     ctr_attributes_set_int64(attr, "release_year", 2014);
 
-    ctr_resources_set_attributes(res, attr);
+    ctr_resource_set_attributes(res, attr);
     return res;
 }
 
-int ctr_resources_set_attributes(struct ctrace_resource *res, struct ctrace_attributes *attr)
+int ctr_resource_set_schema_url(struct ctrace_resource *res, char *url)
+{
+    if (res->schema_url) {
+        cfl_sds_destroy(res->schema_url);
+    }
+
+    res->schema_url = cfl_sds_create(url);
+    if (!res->schema_url) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int ctr_resource_set_attributes(struct ctrace_resource *res, struct ctrace_attributes *attr)
 {
     if (!attr) {
         return -1;
@@ -79,6 +93,11 @@ void ctr_resource_destroy(struct ctrace_resource *res)
     if (res->attr) {
         ctr_attributes_destroy(res->attr);
     }
+
+    if (res->schema_url) {
+        cfl_sds_destroy(res->schema_url);
+    }
+
     cfl_list_del(&res->_head);
     free(res);
 }

--- a/src/ctr_scope.c
+++ b/src/ctr_scope.c
@@ -1,0 +1,124 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <ctraces/ctraces.h>
+
+struct ctrace_scope_span *ctr_scope_span_create(struct ctrace_resource_span *resource_span)
+{
+    struct ctrace_scope_span *scope_span;
+
+    scope_span = calloc(1, sizeof(struct ctrace_scope_span));
+    if (!scope_span) {
+        ctr_errno();
+        return NULL;
+    }
+    cfl_list_init(&scope_span->spans);
+    cfl_list_add(&scope_span->_head, &resource_span->scope_spans);
+
+    return scope_span;
+}
+
+void ctr_scope_span_destroy(struct ctrace_scope_span *scope_span)
+{
+    struct cfl_list *tmp;
+    struct cfl_list *head;
+    struct ctrace_span *span;
+
+    /* release instrumentation scope if set */
+    if (scope_span->instrumentation_scope) {
+        ctr_instrumentation_scope_destroy(scope_span->instrumentation_scope);
+    }
+
+    /* remove linked spans */
+    cfl_list_foreach_safe(head, tmp, &scope_span->spans) {
+        span = cfl_list_entry(head, struct ctrace_span, _head);
+        ctr_span_destroy(span);
+    }
+
+    if (scope_span->schema_url) {
+        cfl_sds_destroy(scope_span->schema_url);
+    }
+
+    cfl_list_del(&scope_span->_head);
+    free(scope_span);
+}
+
+/* Set the schema_url for a resource_span */
+int ctr_scope_span_set_schema_url(struct ctrace_scope_span *scope_span, char *url)
+{
+    if (scope_span->schema_url) {
+        cfl_sds_destroy(scope_span->schema_url);
+    }
+
+    scope_span->schema_url = cfl_sds_create(url);
+    if (!scope_span->schema_url) {
+        return -1;
+    }
+
+    return 0;
+}
+
+void ctr_scope_span_set_instrumentation_scope(struct ctrace_scope_span *scope_span,
+                                              struct ctrace_instrumentation_scope *scope)
+{
+    scope_span->instrumentation_scope = scope;
+}
+
+struct ctrace_instrumentation_scope *ctr_instrumentation_scope_create(char *name, char *version,
+                                                                      uint32_t dropped_attr_count,
+                                                                      struct ctrace_attributes *attr)
+{
+    struct ctrace_instrumentation_scope *ins_scope;
+
+    ins_scope = calloc(1, sizeof(struct ctrace_instrumentation_scope));
+    if (!ins_scope) {
+        ctr_errno();
+        return NULL;
+    }
+
+    if (name) {
+        ins_scope->name = cfl_sds_create(name);
+    }
+    if (version) {
+        ins_scope->version = cfl_sds_create(version);
+    }
+
+    ins_scope->dropped_attr_count = dropped_attr_count;
+    ins_scope->attr = attr;
+
+    return ins_scope;
+}
+
+void ctr_instrumentation_scope_destroy(struct ctrace_instrumentation_scope *ins_scope)
+{
+    if (ins_scope->name) {
+        cfl_sds_destroy(ins_scope->name);
+    }
+
+    if (ins_scope->version) {
+        cfl_sds_destroy(ins_scope->version);
+    }
+
+    if (ins_scope->attr) {
+        ctr_attributes_destroy(ins_scope->attr);
+    }
+
+    free(ins_scope);
+}
+

--- a/src/ctr_span.c
+++ b/src/ctr_span.c
@@ -53,8 +53,8 @@ struct ctrace_span *ctr_span_create(struct ctrace *ctx, cfl_sds_t name,
     span->dropped_attr_count = 0;
 
     /* if a parent context was given, populate the span parent id */
-    if (parent && parent->id) {
-        ctr_span_set_parent_id_with_cid(span, parent->id);
+    if (parent && parent->span_id) {
+        ctr_span_set_parent_span_id_with_cid(span, parent->span_id);
     }
 
     /* link span to the context */
@@ -69,14 +69,14 @@ struct ctrace_span *ctr_span_create(struct ctrace *ctx, cfl_sds_t name,
 }
 
 /* Set the Span ID with a given buffer and length */
-int ctr_span_set_id(struct ctrace_span *span, void *buf, size_t len)
+int ctr_span_set_trace_id(struct ctrace_span *span, void *buf, size_t len)
 {
     if (!buf || len <= 0) {
         return -1;
     }
 
-    span->id = ctr_id_create(buf, len);
-    if (!span->id) {
+    span->trace_id = ctr_id_create(buf, len);
+    if (!span->trace_id) {
         return -1;
     }
 
@@ -84,15 +84,38 @@ int ctr_span_set_id(struct ctrace_span *span, void *buf, size_t len)
 }
 
 /* Set the Span ID by using a ctrace_id context */
-int ctr_span_set_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid)
+int ctr_span_set_trace_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid)
 {
-    return ctr_span_set_id(span,
-                           ctr_id_get_buf(cid),
-                           ctr_id_get_len(cid));
+    return ctr_span_set_trace_id(span,
+                                 ctr_id_get_buf(cid),
+                                 ctr_id_get_len(cid));
+}
+
+/* Set the Span ID with a given buffer and length */
+int ctr_span_set_span_id(struct ctrace_span *span, void *buf, size_t len)
+{
+    if (!buf || len <= 0) {
+        return -1;
+    }
+
+    span->span_id = ctr_id_create(buf, len);
+    if (!span->span_id) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Set the Span ID by using a ctrace_id context */
+int ctr_span_set_span_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid)
+{
+    return ctr_span_set_span_id(span,
+                                ctr_id_get_buf(cid),
+                                ctr_id_get_len(cid));
 }
 
 /* Set the Span Parent ID with a given buffer and length */
-int ctr_span_set_parent_id(struct ctrace_span *span, void *buf, size_t len)
+int ctr_span_set_parent_span_id(struct ctrace_span *span, void *buf, size_t len)
 {
     if (!buf || len <= 0) {
         return -1;
@@ -107,11 +130,11 @@ int ctr_span_set_parent_id(struct ctrace_span *span, void *buf, size_t len)
 }
 
 /* Set the Span ID by using a ctrace_id context */
-int ctr_span_set_parent_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid)
+int ctr_span_set_parent_span_id_with_cid(struct ctrace_span *span, struct ctrace_id *cid)
 {
-    return ctr_span_set_parent_id(span,
-                                  ctr_id_get_buf(cid),
-                                  ctr_id_get_len(cid));
+    return ctr_span_set_parent_span_id(span,
+                                       ctr_id_get_buf(cid),
+                                       ctr_id_get_len(cid));
 }
 
 void ctr_span_set_resource(struct ctrace_span *span, struct ctrace_resource *res)
@@ -251,8 +274,12 @@ void ctr_span_destroy(struct ctrace_span *span)
         cfl_sds_destroy(span->name);
     }
 
-    if (span->id) {
-        ctr_id_destroy(span->id);
+    if (span->trace_id) {
+        ctr_id_destroy(span->trace_id);
+    }
+
+    if (span->span_id) {
+        ctr_id_destroy(span->span_id);
     }
 
     if (span->parent_span_id) {

--- a/src/ctraces.c
+++ b/src/ctraces.c
@@ -26,20 +26,16 @@ void ctr_opts_init(struct ctrace_opts *opts)
 
 void ctr_opts_set(struct ctrace_opts *opts, int value, char *val)
 {
-    if (value == CTR_OPTS_TRACE_ID) {
-        opts->trace_id = cfl_sds_create(val);
-    }
+    /* unused */
+    (void) opts;
+    (void) value;
+    (void) val;
 }
 
 void ctr_opts_exit(struct ctrace_opts *opts)
 {
-
     if (!opts) {
         return;
-    }
-
-    if (opts->trace_id) {
-        cfl_sds_destroy(opts->trace_id);
     }
 }
 
@@ -53,8 +49,8 @@ struct ctrace *ctr_create(struct ctrace_opts *opts)
         ctr_errno();
         return NULL;
     }
-    cfl_list_init(&ctx->resources);
-    cfl_list_init(&ctx->spans);
+    cfl_list_init(&ctx->resource_spans);
+    cfl_list_init(&ctx->span_list);
 
     return ctx;
 }
@@ -63,19 +59,12 @@ void ctr_destroy(struct ctrace *ctx)
 {
     struct cfl_list *head;
     struct cfl_list *tmp;
-    struct ctrace_span *span;
-    struct ctrace_resource *res;
+    struct ctrace_resource_span *resource_span;
 
-    /* delete spans */
-    cfl_list_foreach_safe(head, tmp, &ctx->spans) {
-        span = cfl_list_entry(head, struct ctrace_span, _head);
-        ctr_span_destroy(span);
-    }
-
-    /* delete resouorces */
-    cfl_list_foreach_safe(head, tmp, &ctx->resources) {
-        res = cfl_list_entry(head, struct ctrace_resource, _head);
-        ctr_resource_destroy(res);
+    /* delete resources */
+    cfl_list_foreach_safe(head, tmp, &ctx->resource_spans) {
+        resource_span = cfl_list_entry(head, struct ctrace_resource_span, _head);
+        ctr_resource_span_destroy(resource_span);
     }
 
     free(ctx);

--- a/tests/basic.c
+++ b/tests/basic.c
@@ -39,15 +39,11 @@ void test_options()
 
     /* options */
     ctr_opts_init(&opts);
-    ctr_opts_set(&opts, CTR_OPTS_TRACE_ID, OPTS_TRACE_ID);
-    TEST_CHECK(strcmp(opts.trace_id, OPTS_TRACE_ID) == 0);
 
     /* create & destroy context */
     ctx = ctr_create(&opts);
 
     TEST_CHECK(ctx != NULL);
-    //TEST_CHECK(strcmp(ctx->trace_id, OPTS_TRACE_ID) == 0);
-
     ctr_destroy(ctx);
 
     /* exit options */

--- a/tests/span.c
+++ b/tests/span.c
@@ -32,26 +32,31 @@ void test_span()
     struct ctrace *ctx;
     struct ctrace_span *span_root;
     struct ctrace_span *span_child;
+    struct ctrace_resource_span *resource_span;
+    struct ctrace_scope_span *scope_span;
     struct ctrace_id *id;
     struct cfl_array *array;
     struct cfl_kvlist *kvlist;
 
     ctx = ctr_create(NULL);
 
+    resource_span = ctr_resource_span_create(ctx);
+    scope_span = ctr_scope_span_create(resource_span);
+
     /* create root span */
-    span_root = ctr_span_create(ctx, "main", NULL);
+    span_root = ctr_span_create(ctx, scope_span, "main", NULL);
     TEST_CHECK(span_root != NULL);
     TEST_CHECK(span_root->kind == CTRACE_SPAN_INTERNAL);
 
     /* set the span root a random id */
     id = ctr_id_create_random();
     TEST_CHECK(id != NULL);
-    ctr_span_set_id_with_cid(span_root, id);
+    ctr_span_set_span_id_with_cid(span_root, id);
 
     /* id is not longer needed */
     ctr_id_destroy(id);
 
-    span_child = ctr_span_create(ctx, "do-work", span_root);
+    span_child = ctr_span_create(ctx, scope_span, "do-work", span_root);
     TEST_CHECK(span_child != NULL);
 
     /* set span kind */
@@ -60,7 +65,7 @@ void test_span()
     TEST_CHECK(span_child->kind == CTRACE_SPAN_CONSUMER);
 
     /* parent id check */
-    ret = ctr_id_cmp(span_child->parent_span_id, span_root->id);
+    ret = ctr_id_cmp(span_child->parent_span_id, span_root->span_id);
     TEST_CHECK(ret == 0);
 
     /* add attributes to span_child */


### PR DESCRIPTION
The following patch changes all structures and provides step-by-step interfaces to compose a Trace:

- resource_span
     - resource
     - scope_span
       - instrumentation scope
       - spans
          - links

 It also adjusts the text encoder, 'simple' example, and unit tests.
 
Example output (text encoding) 
```
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - service.name: 'Fluent Bit'
            - release_year: 2014
     - dropped_attributes_count: 0
  schema_url: https://ctraces/resource_span_schema_url
  [scope_span]
    instrumentation scope:
        - name                    : ctrace
        - version                 : a.b.c
        - dropped_attributes_count: 3
        - attributes: undefined
    schema_url: https://ctraces/scope_span_schema_url
    [spans]
         [span 'main']
             - trace_id                : 74280aae2f2713a6d475ba5a52691a2b
             - span_id                 : fdf9869a1d4b542ae1bb5d312d71005d
             - parent_span_id          : undefined
             - kind                    : 1 (internal)
             - start_time              : 1663560945246224176
             - end_time                : 1663560945246224176
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes:
                 - agent: 'Fluent Bit'
                 - year: 2022
                 - open_source: true
                 - temperature: 25.5
                 - my_array: [
                     'first',
                     2,
                     false,
                     [
                         3.1000000000000001,
                         5.2000000000000002,
                         6.2999999999999998
                     ]
                 ]
                 - my-list:
                     - language: 'c'

             - events:
                 - name: connect to remote server
                     - timestamp               : 1663560945246231759
                     - dropped_attributes_count: 0
                     - attributes:
                         - syscall 1: 'open()'
                         - syscall 2: 'connect()'
                         - syscall 3: 'write()'
             - [links]
         [span 'do-work']
             - trace_id                : 74280aae2f2713a6d475ba5a52691a2b
             - span_id                 : cb1ef5537f499dabd535a4d710ca1fe6
             - parent_span_id          : fdf9869a1d4b542ae1bb5d312d71005d
             - kind                    : 3 (client)
             - start_time              : 1663560945246237842
             - end_time                : 1663560945246237842
             - dropped_attributes_count: 0
             - dropped_events_count    : 0
             - status:
                 - code        : 0
             - attributes: none
             - events: none
             - [links]
                 - link:
                     - trace_id             : fa7ee704f240f9b3a8d122d6a6f886c0
                     - span_id              : 92e27aaf526f2e9ade62c3f31591f4e2
                     - trace_state          : aaabbbccc
                     - dropped_events_count : 2
                     - attributes           : none
```