### PR TITLE
encode: opentelemetry: use fluent-otel.h header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,17 @@ if(CTR_HAVE_CFL)
   CTR_DEFINITION(CTR_HAVE_CFL)
 endif()
 
+# Check if fluent-otel-proto library is available in the environment, if not,
+# we will try to build a local copy at a later stage
+check_c_source_compiles("
+  #include <fluent-otel-proto/fluent-otel_found.h>
+  int main() {
+     return fluent_otel_found();
+  }" CTR_HAVE_FLUENT_OTEL_PROTO)
+if(CTR_HAVE_FLUENT_OTEL_PROTO)
+  CTR_DEFINITION(CTR_HAVE_FLUENT_OTEL_PROTO)
+endif()
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/include/ctraces/ctr_info.h.in"
   "${PROJECT_SOURCE_DIR}/include/ctraces/ctr_info.h"

--- a/src/ctr_encode_opentelemetry.c
+++ b/src/ctr_encode_opentelemetry.c
@@ -18,7 +18,7 @@
  */
 
 #include <ctraces/ctraces.h>
-#include <opentelemetry/opentelemetry_trace_service.pb-c.h>
+#include <fluent-otel-proto/fluent-otel.h>
 
 static inline Opentelemetry__Proto__Common__V1__AnyValue *ctr_variant_to_otlp_any_value(struct cfl_variant *value);
 static inline Opentelemetry__Proto__Common__V1__KeyValue *ctr_variant_kvpair_to_otlp_kvpair(struct cfl_kvpair *input_pair);


### PR DESCRIPTION
Signed-off-by: Eduardo Silva <eduardo@calyptia.com>