### PR TITLE
decode: msgpack decoder addition

### DIFF
--- a/include/ctraces/ctr_decode_msgpack.h
+++ b/include/ctraces/ctr_decode_msgpack.h
@@ -1,0 +1,44 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CTR_DECODE_MSGPACK_H
+#define CTR_DECODE_MSGPACK_H
+
+#include <ctraces/ctraces.h>
+
+#define CTR_DECODE_MSGPACK_SUCCESS                (CTR_MPACK_SUCCESS)
+#define CTR_DECODE_MSGPACK_INVALID_ARGUMENT_ERROR (CTR_MPACK_INVALID_ARGUMENT_ERROR)
+#define CTR_DECODE_MSGPACK_INVALID_STATE          (CTR_MPACK_ERROR_CUTOFF + 1)
+#define CTR_DECODE_MSGPACK_ALLOCATION_ERROR       (CTR_MPACK_ERROR_CUTOFF + 2)
+#define CTR_DECODE_MSGPACK_VARIANT_DECODE_ERROR   (CTR_MPACK_ERROR_CUTOFF + 3)
+
+struct ctr_msgpack_decode_context {
+    struct ctrace_resource_span *resource_span;
+    struct ctrace_scope_span    *scope_span;
+    struct ctrace_resource      *resource;
+    struct ctrace               *trace;
+    struct ctrace_span_event    *event;
+    struct ctrace_span          *span;
+    struct ctrace_link          *link;
+};
+
+int ctr_decode_msgpack_create(struct ctrace **out_context, char *in_buf, size_t in_size, size_t *offset);
+void ctr_decode_msgpack_destroy(struct ctrace *context);
+
+#endif

--- a/include/ctraces/ctr_mpack_utils.h
+++ b/include/ctraces/ctr_mpack_utils.h
@@ -1,0 +1,56 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CTR_MPACK_UTILS_H
+#define CTR_MPACK_UTILS_H
+
+#include <ctraces/ctr_mpack_utils_defs.h>
+#include <cfl/cfl_sds.h>
+#include <mpack/mpack.h>
+
+typedef int (*ctr_mpack_unpacker_entry_callback_fn_t)(mpack_reader_t *reader,
+                                                      size_t index, void *context);
+
+struct ctr_mpack_map_entry_callback_t {
+    const char                            *identifier;
+    ctr_mpack_unpacker_entry_callback_fn_t handler;
+};
+
+int ctr_mpack_consume_nil_tag(mpack_reader_t *reader);
+int ctr_mpack_consume_double_tag(mpack_reader_t *reader, double *output_buffer);
+int ctr_mpack_consume_int_tag(mpack_reader_t *reader, int64_t *output_buffer);
+int ctr_mpack_consume_int32_tag(mpack_reader_t *reader, int32_t *output_buffer);
+int ctr_mpack_consume_int64_tag(mpack_reader_t *reader, int64_t *output_buffer);
+int ctr_mpack_consume_uint_tag(mpack_reader_t *reader, uint64_t *output_buffer);
+int ctr_mpack_consume_uint32_tag(mpack_reader_t *reader, uint32_t *output_buffer);
+int ctr_mpack_consume_uint64_tag(mpack_reader_t *reader, uint64_t *output_buffer);
+int ctr_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer);
+int ctr_mpack_consume_binary_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer);
+int ctr_mpack_consume_string_or_nil_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer);
+int ctr_mpack_consume_binary_or_nil_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer);
+int ctr_mpack_unpack_map(mpack_reader_t *reader,
+                         struct ctr_mpack_map_entry_callback_t *callback_list,
+                         void *context);
+int ctr_mpack_unpack_array(mpack_reader_t *reader,
+                           ctr_mpack_unpacker_entry_callback_fn_t entry_processor_callback,
+                           void *context);
+int ctr_mpack_peek_array_length(mpack_reader_t *reader);
+mpack_type_t ctr_mpack_peek_type(mpack_reader_t *reader);
+
+#endif

--- a/include/ctraces/ctr_mpack_utils_defs.h
+++ b/include/ctraces/ctr_mpack_utils_defs.h
@@ -1,0 +1,40 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CTR_MPACK_UTILS_DEFS_H
+#define CTR_MPACK_UTILS_DEFS_H
+
+#define CTR_MPACK_SUCCESS                    0
+#define CTR_MPACK_INSUFFICIENT_DATA          1
+#define CTR_MPACK_INVALID_ARGUMENT_ERROR     2
+#define CTR_MPACK_ALLOCATION_ERROR           3
+#define CTR_MPACK_CORRUPT_INPUT_DATA_ERROR   4
+#define CTR_MPACK_CONSUME_ERROR              5
+#define CTR_MPACK_ENGINE_ERROR               6
+#define CTR_MPACK_PENDING_MAP_ENTRIES        7
+#define CTR_MPACK_PENDING_ARRAY_ENTRIES      8
+#define CTR_MPACK_UNEXPECTED_KEY_ERROR       9
+#define CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR 10
+#define CTR_MPACK_ERROR_CUTOFF               20
+
+#define CTR_MPACK_MAX_ARRAY_ENTRY_COUNT      65535
+#define CTR_MPACK_MAX_MAP_ENTRY_COUNT        20
+#define CTR_MPACK_MAX_STRING_LENGTH          1024
+
+#endif

--- a/include/ctraces/ctr_variant_utils.h
+++ b/include/ctraces/ctr_variant_utils.h
@@ -1,0 +1,627 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef CTR_VARIANT_UTILS_H
+#define CTR_VARIANT_UTILS_H
+
+#include <mpack/mpack.h>
+
+/* These are the only functions meant for general use,
+ * the reason why the kvlist packing and unpacking
+ * functions are exposed is the internal and external
+ * metadata kvlists in the cmetrics context are not
+ * contained by a variant instance.
+ *
+ * Result :
+ * Upon success all of these return 0, otherwise they will
+ * raise the innermost error code which should be treated
+ * as an opaque value.
+ *
+ * Notes :
+ * When decoding -1 means the check after mpack_read_tag
+ * failed and -2 means the type was not the one expected
+ */
+
+static inline int pack_cfl_variant(mpack_writer_t *writer,
+                                   struct cfl_variant *value);
+
+static inline int pack_cfl_variant_kvlist(mpack_writer_t *writer,
+                                          struct cfl_kvlist *kvlist);
+
+static inline int unpack_cfl_variant(mpack_reader_t *reader,
+                                     struct cfl_variant **value);
+
+static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
+                                    struct cfl_kvlist **result_kvlist);
+
+/* Packers */
+static inline int pack_cfl_variant_string(mpack_writer_t *writer,
+                                          char *value)
+{
+    mpack_write_cstr(writer, value);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant_binary(mpack_writer_t *writer,
+                                          char *value,
+                                          size_t length)
+{
+    mpack_write_bin(writer, value, length);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant_boolean(mpack_writer_t *writer,
+                                           unsigned int value)
+{
+    mpack_write_bool(writer, value);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant_int64(mpack_writer_t *writer,
+                                         int64_t value)
+{
+    mpack_write_int(writer, value);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant_double(mpack_writer_t *writer,
+                                          double value)
+{
+    mpack_write_double(writer, value);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant_array(mpack_writer_t *writer,
+                                         struct cfl_array *array)
+{
+    size_t              entry_count;
+    struct cfl_variant *entry_value;
+    int                 result;
+    size_t              index;
+
+    entry_count = array->entry_count;
+
+    mpack_start_array(writer, entry_count);
+
+    for (index = 0 ; index < entry_count ; index++) {
+        entry_value = cfl_array_fetch_by_index(array, index);
+
+        if (entry_value == NULL) {
+            return -1;
+        }
+
+        result = pack_cfl_variant(writer, entry_value);
+
+        if (result != 0) {
+            return result;
+        }
+    }
+
+    mpack_finish_array(writer);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant_kvlist(mpack_writer_t *writer,
+                                          struct cfl_kvlist *kvlist) {
+    size_t             entry_count;
+    struct cfl_list   *iterator;
+    struct cfl_kvpair *kvpair;
+    int                result;
+
+    entry_count = cfl_kvlist_count(kvlist);
+
+    mpack_start_map(writer, entry_count);
+
+    cfl_list_foreach(iterator, &kvlist->list) {
+        kvpair = cfl_list_entry(iterator, struct cfl_kvpair, _head);
+
+        mpack_write_cstr(writer, kvpair->key);
+
+        result = pack_cfl_variant(writer, kvpair->val);
+
+        if (result != 0) {
+            return result;
+        }
+    }
+
+    mpack_finish_map(writer);
+
+    return 0;
+}
+
+static inline int pack_cfl_variant(mpack_writer_t *writer,
+                                   struct cfl_variant *value)
+{
+    int result;
+
+    if (value->type == CFL_VARIANT_STRING) {
+        result = pack_cfl_variant_string(writer, value->data.as_string);
+    }
+    else if (value->type == CFL_VARIANT_BOOL) {
+        result = pack_cfl_variant_boolean(writer, value->data.as_bool);
+    }
+    else if (value->type == CFL_VARIANT_INT) {
+        result = pack_cfl_variant_int64(writer, value->data.as_int64);
+    }
+    else if (value->type == CFL_VARIANT_DOUBLE) {
+        result = pack_cfl_variant_double(writer, value->data.as_double);
+    }
+    else if (value->type == CFL_VARIANT_ARRAY) {
+        result = pack_cfl_variant_array(writer, value->data.as_array);
+    }
+    else if (value->type == CFL_VARIANT_KVLIST) {
+        result = pack_cfl_variant_kvlist(writer, value->data.as_kvlist);
+    }
+    else if (value->type == CFL_VARIANT_BYTES) {
+        result = pack_cfl_variant_binary(writer,
+                                         value->data.as_bytes,
+                                         cfl_sds_len(value->data.as_bytes));
+    }
+    else if (value->type == CFL_VARIANT_REFERENCE) {
+        result = pack_cfl_variant_string(writer, value->data.as_string);
+    }
+    else {
+        result = -1;
+    }
+
+    return result;
+}
+
+/* Unpackers */
+
+static inline int unpack_cfl_variant_read_tag(mpack_reader_t *reader,
+                                              mpack_tag_t *tag,
+                                              mpack_type_t expected_type)
+{
+    *tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return -1;
+    }
+
+    if (mpack_tag_type(tag) != expected_type) {
+        return -2;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_array(mpack_reader_t *reader,
+                                   struct cfl_array **result_array)
+{
+    struct cfl_array   *internal_array;
+    size_t              entry_count;
+    struct cfl_variant *entry_value;
+    int                 result;
+    size_t              index;
+    mpack_tag_t         tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_array);
+
+    if (result != 0) {
+        return result;
+    }
+
+    entry_count = mpack_tag_array_count(&tag);
+
+    internal_array = cfl_array_create(entry_count);
+
+    if (internal_array == NULL) {
+        return -3;
+    }
+
+    for (index = 0 ; index < entry_count ; index++) {
+        result = unpack_cfl_variant(reader, &entry_value);
+
+        if (result != 0) {
+            cfl_array_destroy(internal_array);
+
+            return -4;
+        }
+
+        result = cfl_array_append(internal_array, entry_value);
+
+        if (result != 0) {
+            cfl_array_destroy(internal_array);
+
+            return -5;
+        }
+    }
+
+    mpack_done_array(reader);
+
+    if (mpack_reader_error(reader) != mpack_ok) {
+        cfl_array_destroy(internal_array);
+
+        return -6;
+    }
+
+    *result_array = internal_array;
+
+    return 0;
+}
+
+static inline int unpack_cfl_kvlist(mpack_reader_t *reader,
+                                    struct cfl_kvlist **result_kvlist)
+{
+    struct cfl_kvlist   *internal_kvlist;
+    char                 key_name[256];
+    size_t               entry_count;
+    size_t               key_length;
+    struct cfl_variant  *key_value;
+    mpack_tag_t          key_tag;
+    int                  result;
+    size_t               index;
+    mpack_tag_t          tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_map);
+
+    if (result != 0) {
+        return result;
+    }
+
+    entry_count = mpack_tag_map_count(&tag);
+
+    internal_kvlist = cfl_kvlist_create();
+
+    if (internal_kvlist == NULL) {
+        return -3;
+    }
+
+    result = 0;
+    key_value = NULL;
+
+    for (index = 0 ; index < entry_count ; index++) {
+        result = unpack_cfl_variant_read_tag(reader, &key_tag, mpack_type_str);
+
+        if (result != 0) {
+            result = -4;
+
+            break;
+        }
+
+        key_length = mpack_tag_str_length(&key_tag);
+
+        if (key_length >= sizeof(key_name)) {
+            result = -5;
+
+            break;
+        }
+
+        mpack_read_cstr(reader, key_name, sizeof(key_name), key_length);
+
+        key_name[key_length] = '\0';
+
+        mpack_done_str(reader);
+
+        if (mpack_ok != mpack_reader_error(reader)) {
+            result = -6;
+
+            break;
+        }
+
+        result = unpack_cfl_variant(reader, &key_value);
+
+        if (result != 0) {
+            printf("VARIANT UNPACK ERROR : [%s] = %d\n", key_name, result);
+            result = -7;
+
+            break;
+        }
+
+        result = cfl_kvlist_insert(internal_kvlist, key_name, key_value);
+
+        if (result != 0) {
+            result = -8;
+
+            break;
+        }
+
+        key_value = NULL;
+    }
+
+    mpack_done_map(reader);
+
+    if (mpack_reader_error(reader) != mpack_ok) {
+        result = -9;
+    }
+
+    if (result != 0) {
+        cfl_kvlist_destroy(internal_kvlist);
+
+        if (key_value != NULL) {
+            cfl_variant_destroy(key_value);
+        }
+    }
+    else {
+        *result_kvlist = internal_kvlist;
+    }
+
+    return result;
+}
+
+static inline int unpack_cfl_variant_string(mpack_reader_t *reader,
+                                            struct cfl_variant **value)
+{
+    size_t      value_length;
+    char       *value_data;
+    int         result;
+    mpack_tag_t tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_str);
+
+    if (result != 0) {
+        return result;
+    }
+
+    value_length = mpack_tag_str_length(&tag);
+
+    value_data = cfl_sds_create_size(value_length + 1);
+
+    if (value_data == NULL) {
+        return -3;
+    }
+
+    cfl_sds_set_len(value_data, value_length);
+
+    mpack_read_cstr(reader, value_data, value_length + 1, value_length);
+
+    mpack_done_str(reader);
+
+    if (mpack_reader_error(reader) != mpack_ok) {
+        cfl_sds_destroy(value_data);
+
+        return -4;
+    }
+
+    *value = cfl_variant_create_from_reference(value_data);
+
+    if (*value == NULL) {
+        return -5;
+    }
+
+    (*value)->type = CFL_VARIANT_STRING;
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_binary(mpack_reader_t *reader,
+                                            struct cfl_variant **value)
+{
+    size_t      value_length;
+    char       *value_data;
+    int         result;
+    mpack_tag_t tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_bin);
+
+    if (result != 0) {
+        return result;
+    }
+
+    value_length = mpack_tag_bin_length(&tag);
+
+    value_data = cfl_sds_create_size(value_length);
+
+    if (value_data == NULL) {
+        return -3;
+    }
+
+    cfl_sds_set_len(value_data, value_length);
+
+    mpack_read_bytes(reader, value_data, value_length);
+
+    mpack_done_bin(reader);
+
+    if (mpack_reader_error(reader) != mpack_ok) {
+        cfl_sds_destroy(value_data);
+
+        return -4;
+    }
+
+    *value = cfl_variant_create_from_reference(value_data);
+
+    if (*value == NULL) {
+        return -5;
+    }
+
+    (*value)->type = CFL_VARIANT_BYTES;
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_boolean(mpack_reader_t *reader,
+                                             struct cfl_variant **value)
+{
+    int         result;
+    mpack_tag_t tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_bool);
+
+    if (result != 0) {
+        return result;
+    }
+
+    *value = cfl_variant_create_from_bool((unsigned int) mpack_tag_bool_value(&tag));
+
+    if (*value == NULL) {
+        return -3;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_uint64(mpack_reader_t *reader,
+                                            struct cfl_variant **value)
+{
+    int         result;
+    mpack_tag_t tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_uint);
+
+    if (result != 0) {
+        return result;
+    }
+
+    *value = cfl_variant_create_from_int64((int64_t) mpack_tag_uint_value(&tag));
+
+    if (*value == NULL) {
+        return -3;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_int64(mpack_reader_t *reader,
+                                           struct cfl_variant **value)
+{
+    int         result;
+    mpack_tag_t tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_int);
+
+    if (result != 0) {
+        return result;
+    }
+
+    *value = cfl_variant_create_from_int64((int64_t) mpack_tag_int_value(&tag));
+
+    if (*value == NULL) {
+        return -3;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_double(mpack_reader_t *reader,
+                                            struct cfl_variant **value)
+{
+    int         result;
+    mpack_tag_t tag;
+
+    result = unpack_cfl_variant_read_tag(reader, &tag, mpack_type_double);
+
+    if (result != 0) {
+        return result;
+    }
+
+    *value = cfl_variant_create_from_double(mpack_tag_double_value(&tag));
+
+    if (*value == NULL) {
+        return -3;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_array(mpack_reader_t *reader,
+                                           struct cfl_variant **value)
+{
+    struct cfl_array *unpacked_array;
+    int               result;
+
+    result = unpack_cfl_array(reader, &unpacked_array);
+
+    if (result != 0) {
+        return result;
+    }
+
+    *value = cfl_variant_create_from_array(unpacked_array);
+
+    if (*value == NULL) {
+        return -3;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant_kvlist(mpack_reader_t *reader,
+                                            struct cfl_variant **value)
+{
+    struct cfl_kvlist *unpacked_kvlist;
+    int                result;
+
+    result = unpack_cfl_kvlist(reader, &unpacked_kvlist);
+
+    if (result != 0) {
+        return result;
+    }
+
+    *value = cfl_variant_create_from_kvlist(unpacked_kvlist);
+
+    if (*value == NULL) {
+        return -3;
+    }
+
+    return 0;
+}
+
+static inline int unpack_cfl_variant(mpack_reader_t *reader,
+                                     struct cfl_variant **value)
+{
+    mpack_type_t value_type;
+    int          result;
+    mpack_tag_t  tag;
+
+    tag = mpack_peek_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return -1;
+    }
+
+    value_type = mpack_tag_type(&tag);
+
+    if (value_type == mpack_type_str) {
+        result = unpack_cfl_variant_string(reader, value);
+    }
+    else if (value_type == mpack_type_bool) {
+        result = unpack_cfl_variant_boolean(reader, value);
+    }
+    else if (value_type == mpack_type_int) {
+        result = unpack_cfl_variant_int64(reader, value);
+    }
+    else if (value_type == mpack_type_uint) {
+        result = unpack_cfl_variant_uint64(reader, value);
+    }
+    else if (value_type == mpack_type_double) {
+        result = unpack_cfl_variant_double(reader, value);
+    }
+    else if (value_type == mpack_type_array) {
+        result = unpack_cfl_variant_array(reader, value);
+    }
+    else if (value_type == mpack_type_map) {
+        result = unpack_cfl_variant_kvlist(reader, value);
+    }
+    else if (value_type == mpack_type_bin) {
+        result = unpack_cfl_variant_binary(reader, value);
+    }
+    else {
+        result = -1;
+    }
+
+    return result;
+}
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,11 +9,13 @@ set(src
   ctr_random.c
   ctr_utils.c
   ctr_attributes.c
+  ctr_mpack_utils.c
   # encoders
   ctr_encode_text.c
   ctr_encode_msgpack.c
   ctr_encode_opentelemetry.c
   # decoders
+  ctr_decode_msgpack.c
   ctr_decode_opentelemetry.c
   )
 

--- a/src/ctr_decode_msgpack.c
+++ b/src/ctr_decode_msgpack.c
@@ -1,0 +1,669 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <ctraces/ctraces.h>
+#include <ctraces/ctr_mpack_utils.h>
+#include <ctraces/ctr_decode_msgpack.h>
+#include <cfl/cfl_sds.h>
+#include <ctraces/ctr_variant_utils.h>
+
+
+/* Resource callbacks */
+
+static int unpack_resource_dropped_attributes_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(
+            reader, &context->resource->dropped_attr_count);
+}
+
+static int unpack_resource_attributes(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    struct cfl_kvlist                 *attributes;
+    int                                result;
+
+    if (ctr_mpack_peek_type(reader) == mpack_type_nil) {
+        result = ctr_mpack_consume_nil_tag(reader);
+    }
+    else {
+        result = unpack_cfl_kvlist(reader, &attributes);
+
+        if (result == 0) {
+            cfl_kvlist_destroy(context->resource->attr->kv);
+
+            context->resource->attr->kv = attributes;
+        }
+    }
+
+    return result;
+}
+
+static int unpack_resource(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"attributes",               unpack_resource_attributes},
+            {"dropped_attributes_count", unpack_resource_dropped_attributes_count},
+            {NULL,                       NULL}
+        };
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+
+/* Instrumentation scope callbacks */
+
+static int unpack_instrumentation_scope_name(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_string_or_nil_tag(
+            reader,
+            &context->scope_span->instrumentation_scope->name);
+}
+
+static int unpack_instrumentation_scope_version(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_string_or_nil_tag(
+            reader,
+            &context->scope_span->instrumentation_scope->version);
+}
+
+static int unpack_instrumentation_scope_dropped_attribute_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(
+            reader,
+            &context->scope_span->instrumentation_scope->dropped_attr_count);
+}
+
+static int unpack_instrumentation_scope_attributes(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    struct ctrace_attributes          *attributes;
+    int                                result;
+
+    attributes = ctr_attributes_create();
+
+    cfl_kvlist_destroy(attributes->kv);
+
+    attributes->kv = NULL;
+
+    result = unpack_cfl_kvlist(reader, &attributes->kv);
+
+    if (result != 0) {
+        return CTR_DECODE_MSGPACK_VARIANT_DECODE_ERROR;
+    }
+
+    context->scope_span->instrumentation_scope->attr = attributes;
+
+    return CTR_DECODE_MSGPACK_SUCCESS;
+}
+
+static int unpack_scope_span_instrumentation_scope(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctrace_instrumentation_scope  *instrumentation_scope;
+    struct ctr_msgpack_decode_context    *context = ctx;
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"name",                     unpack_instrumentation_scope_name},
+            {"version",                  unpack_instrumentation_scope_version},
+            {"attributes",               unpack_instrumentation_scope_attributes},
+            {"dropped_attributes_count", unpack_instrumentation_scope_dropped_attribute_count},
+            {NULL,                       NULL}
+        };
+
+    instrumentation_scope = ctr_instrumentation_scope_create(NULL, NULL, 0, NULL);
+
+    if (instrumentation_scope == NULL) {
+        return CTR_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    ctr_scope_span_set_instrumentation_scope(context->scope_span, instrumentation_scope);
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+/* Event callbacks */
+
+static int unpack_event_name(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    if (context->event->name != NULL) {
+        cfl_sds_destroy(context->event->name);
+
+        context->event->name = NULL;
+    }
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->event->name);
+}
+
+static int unpack_event_time_unix_nano(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint64_tag(reader, &context->event->time_unix_nano);
+}
+
+static int unpack_event_attributes(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    struct cfl_kvlist                 *attributes;
+    int                                result;
+
+    if (ctr_mpack_peek_type(reader) == mpack_type_nil) {
+        ctr_mpack_consume_nil_tag(reader);
+
+        return CTR_DECODE_MSGPACK_SUCCESS;
+    }
+
+    result = unpack_cfl_kvlist(reader, &attributes);
+
+    if (result != 0) {
+        return CTR_DECODE_MSGPACK_VARIANT_DECODE_ERROR;
+    }
+
+    cfl_kvlist_destroy(context->event->attr->kv);
+    context->event->attr->kv = attributes;
+
+    return CTR_DECODE_MSGPACK_SUCCESS;
+}
+
+static int unpack_event_dropped_attributes_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(reader, &context->event->dropped_attr_count);
+}
+
+static int unpack_event(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context    *context = ctx;
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"name",                     unpack_event_name},
+            {"time_unix_nano",           unpack_event_time_unix_nano},
+            {"attributes",               unpack_event_attributes},
+            {"dropped_attributes_count", unpack_event_dropped_attributes_count},
+            {NULL,                       NULL}
+        };
+
+    context->event = ctr_span_event_add(context->span, "");
+
+    if (context->event == NULL) {
+        return CTR_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+/* Link callbacks */
+
+static int unpack_link_trace_id(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    int                                result;
+    cfl_sds_t                          value;
+
+    result = ctr_mpack_consume_binary_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS) {
+        context->link->trace_id = ctr_id_create(value, cfl_sds_len(value));
+
+        cfl_sds_destroy(value);
+    }
+
+    return result;
+}
+
+static int unpack_link_span_id(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    int                                result;
+    cfl_sds_t                          value;
+
+    result = ctr_mpack_consume_binary_or_nil_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS &&
+        value != NULL) {
+        context->link->span_id = ctr_id_create(value, cfl_sds_len(value));
+
+        cfl_sds_destroy(value);
+    }
+
+    return result;
+}
+
+static int unpack_link_trace_state(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->link->trace_state);
+}
+
+static int unpack_link_dropped_attributes_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(reader, &context->link->dropped_attr_count);
+}
+
+static int unpack_link_attributes(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    struct cfl_kvlist                 *attributes;
+    int                                result;
+
+    if (ctr_mpack_peek_type(reader) == mpack_type_nil) {
+        result = ctr_mpack_consume_nil_tag(reader);
+    }
+    else {
+        result = unpack_cfl_kvlist(reader, &attributes);
+
+        if (result == 0) {
+            if (context->link->attr == NULL) {
+                context->link->attr = ctr_attributes_create();
+            }
+
+            if (context->link->attr->kv != NULL) {
+                cfl_kvlist_destroy(context->link->attr->kv);
+            }
+
+            context->link->attr->kv = attributes;
+
+            result = CTR_DECODE_MSGPACK_SUCCESS;
+        }
+        else {
+            result = CTR_DECODE_MSGPACK_VARIANT_DECODE_ERROR;
+        }
+    }
+
+    return result;
+}
+
+static int unpack_link(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context    *context = ctx;
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"trace_id",                 unpack_link_trace_id},
+            {"span_id",                  unpack_link_span_id},
+            {"trace_state",              unpack_link_trace_state},
+            {"attributes",               unpack_link_attributes},
+            {"dropped_attributes_count", unpack_link_dropped_attributes_count},
+            {NULL,                       NULL}
+        };
+
+    context->link = ctr_link_create(context->span, NULL, 0, NULL, 0);
+
+    if (context->link == NULL) {
+        return CTR_MPACK_ALLOCATION_ERROR;
+    }
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+/* Span callbacks */
+
+static int unpack_span_trace_id(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    int                                result;
+    cfl_sds_t                          value;
+
+    result = ctr_mpack_consume_binary_or_nil_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS && value != NULL) {
+        ctr_span_set_trace_id(context->span, value, cfl_sds_len(value));
+
+        cfl_sds_destroy(value);
+    }
+
+    return result;
+}
+
+static int unpack_span_span_id(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    int                                result;
+    cfl_sds_t                          value;
+
+    result = ctr_mpack_consume_binary_or_nil_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS && value != NULL) {
+        ctr_span_set_span_id(context->span, value, cfl_sds_len(value));
+
+        cfl_sds_destroy(value);
+    }
+
+    return result;
+}
+
+static int unpack_span_parent_span_id(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    int                                result;
+    cfl_sds_t                          value;
+
+    result = ctr_mpack_consume_binary_or_nil_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS && value != NULL) {
+        ctr_span_set_parent_span_id(context->span, value, cfl_sds_len(value));
+
+        cfl_sds_destroy(value);
+    }
+
+    return result;
+}
+
+static int unpack_span_trace_state(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    if (context->span->trace_state != NULL) {
+        cfl_sds_destroy(context->span->trace_state);
+
+        context->span->trace_state = NULL;
+    }
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->span->trace_state);
+}
+
+static int unpack_span_name(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    if (context->span->name != NULL) {
+        cfl_sds_destroy(context->span->name);
+
+        context->span->name = NULL;
+    }
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->span->name);
+}
+
+static int unpack_span_kind(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_int32_tag(reader, &context->span->kind);
+}
+
+static int unpack_span_start_time_unix_nano(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint64_tag(reader, &context->span->start_time_unix_nano);
+}
+
+static int unpack_span_end_time_unix_nano(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint64_tag(reader, &context->span->end_time_unix_nano);
+}
+
+static int unpack_span_attributes(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+    struct cfl_kvlist                 *attributes;
+    int                                result;
+
+    if (ctr_mpack_peek_type(reader) == mpack_type_nil) {
+        ctr_mpack_consume_nil_tag(reader);
+
+        return CTR_DECODE_MSGPACK_SUCCESS;
+    }
+
+    result = unpack_cfl_kvlist(reader, &attributes);
+
+    if (result != 0) {
+        return CTR_DECODE_MSGPACK_VARIANT_DECODE_ERROR;
+    }
+
+    cfl_kvlist_destroy(context->span->attr->kv);
+    context->span->attr->kv = attributes;
+
+    return CTR_DECODE_MSGPACK_SUCCESS;
+}
+
+static int unpack_span_dropped_attributes_count(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_uint32_tag(reader, &context->span->dropped_attr_count);
+}
+
+static int unpack_span_events(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    return ctr_mpack_unpack_array(reader, unpack_event, ctx);
+}
+
+
+static int unpack_span_links(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    return ctr_mpack_unpack_array(reader, unpack_link, ctx);
+}
+
+static int unpack_span_status_code(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_int32_tag(reader, &context->span->status.code);
+}
+
+static int unpack_span_status_message(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->span->status.message);
+}
+
+static int unpack_span_status(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"code",    unpack_span_status_code},
+            {"message", unpack_span_status_message},
+            {NULL,      NULL}
+        };
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+static int unpack_span(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context    *context = ctx;
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"trace_id",                 unpack_span_trace_id},
+            {"span_id",                  unpack_span_span_id},
+            {"parent_span_id",           unpack_span_parent_span_id},
+            {"trace_state",              unpack_span_trace_state},
+            {"name",                     unpack_span_name},
+            {"kind",                     unpack_span_kind},
+            {"start_time_unix_nano",     unpack_span_start_time_unix_nano},
+            {"end_time_unix_nano",       unpack_span_end_time_unix_nano},
+            {"attributes",               unpack_span_attributes},
+            {"dropped_attributes_count", unpack_span_dropped_attributes_count},
+            {"events",                   unpack_span_events},
+            {"links",                    unpack_span_links},
+            {"status",                   unpack_span_status},
+            {NULL,                       NULL}
+        };
+
+    context->span = ctr_span_create(context->trace, context->scope_span, "", NULL);
+
+    if (context->span == NULL) {
+        return CTR_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+/* Scope span callbacks */
+
+static int unpack_scope_span_spans(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    return ctr_mpack_unpack_array(reader, unpack_span, ctx);
+}
+
+static int unpack_scope_span_schema_url(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    if (context->scope_span->schema_url != NULL) {
+        cfl_sds_destroy(context->scope_span->schema_url);
+
+        context->scope_span->schema_url = NULL;
+    }
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->scope_span->schema_url);
+}
+
+static int unpack_scope_span(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context    *context = ctx;
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"scope",      unpack_scope_span_instrumentation_scope},
+            {"spans",      unpack_scope_span_spans},
+            {"schema_url", unpack_scope_span_schema_url},
+            {NULL,         NULL}
+        };
+
+    context->scope_span = ctr_scope_span_create(context->resource_span);
+
+    if (context->scope_span == NULL) {
+        return CTR_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+/* Resource span callbacks */
+
+static int unpack_resource_span_scope_spans(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    return ctr_mpack_unpack_array(reader, unpack_scope_span, ctx);
+}
+
+static int unpack_resource_span_schema_url(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context *context = ctx;
+
+    if (context->resource_span->schema_url != NULL) {
+        cfl_sds_destroy(context->resource_span->schema_url);
+
+        context->resource_span->schema_url = NULL;
+    }
+
+    return ctr_mpack_consume_string_or_nil_tag(reader, &context->resource_span->schema_url);
+}
+
+static int unpack_resource_span(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    struct ctr_msgpack_decode_context    *context = ctx;
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"resource",    unpack_resource},
+            {"schema_url",  unpack_resource_span_schema_url},
+            {"scope_spans", unpack_resource_span_scope_spans},
+            {NULL,          NULL}
+        };
+
+    context->resource_span = ctr_resource_span_create(context->trace);
+
+    if (context->resource_span == NULL) {
+        return CTR_DECODE_MSGPACK_ALLOCATION_ERROR;
+    }
+
+    context->resource = context->resource_span->resource;
+
+    return ctr_mpack_unpack_map(reader, callbacks, ctx);
+}
+
+/* Outermost block callbacks*/
+
+static int unpack_resource_spans(mpack_reader_t *reader, size_t index, void *ctx)
+{
+    return ctr_mpack_unpack_array(reader, unpack_resource_span, ctx);
+}
+
+static int unpack_context(mpack_reader_t *reader, struct ctr_msgpack_decode_context *ctx)
+{
+    struct ctr_mpack_map_entry_callback_t callbacks[] = \
+        {
+            {"resourceSpans", unpack_resource_spans},
+            {NULL,            NULL}
+        };
+
+    return ctr_mpack_unpack_map(reader, callbacks, (void *) ctx);
+}
+
+int ctr_decode_msgpack_create(struct ctrace **out_context, char *in_buf, size_t in_size, size_t *offset)
+{
+    size_t                            remainder;
+    struct ctr_msgpack_decode_context context;
+    mpack_reader_t                    reader;
+    int                               result;
+
+    memset(&context, 0, sizeof(context));
+
+    context.trace = ctr_create(NULL);
+
+    if (context.trace == NULL) {
+        return -1;
+    }
+
+    in_size -= *offset;
+
+    mpack_reader_init_data(&reader, &in_buf[*offset], in_size);
+
+    result = unpack_context(&reader, &context);
+
+    remainder = mpack_reader_remaining(&reader, NULL);
+
+    *offset += in_size - remainder;
+
+    mpack_reader_destroy(&reader);
+
+    if (result != CTR_DECODE_MSGPACK_SUCCESS) {
+        ctr_destroy(context.trace);
+
+        context.trace = NULL;
+    }
+
+    *out_context = context.trace;
+
+    return result;
+}
+
+void ctr_decode_msgpack_destroy(struct ctrace *context)
+{
+    if (context != NULL) {
+        ctr_destroy(context);
+    }
+}

--- a/src/ctr_id.c
+++ b/src/ctr_id.c
@@ -133,7 +133,7 @@ cfl_sds_t ctr_id_to_lower_base16(struct ctrace_id *cid)
     }
 
     len = cfl_sds_len(cid->buf);
-    out = cfl_sds_create_size(len * 2);
+    out = cfl_sds_create_size(len * 2 + 1);
     if (!out) {
         return NULL;
     }
@@ -142,6 +142,8 @@ cfl_sds_t ctr_id_to_lower_base16(struct ctrace_id *cid)
         out[i * 2] = hex[(cid->buf[i] >> 4) & 0xF];
         out[i * 2 + 1] = hex[(cid->buf[i] >> 0) & 0xF];
     }
+
+    out[i * 2] = 0;
 
     return out;
 }

--- a/src/ctr_mpack_utils.c
+++ b/src/ctr_mpack_utils.c
@@ -1,0 +1,482 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CTraces
+ *  =======
+ *  Copyright 2022 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <ctraces/ctr_mpack_utils.h>
+#include <cfl/cfl_sds.h>
+#include <mpack/mpack.h>
+
+int ctr_mpack_consume_string_or_nil_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer)
+{
+    int result;
+
+    if (ctr_mpack_peek_type(reader) == mpack_type_str) {
+        result = ctr_mpack_consume_string_tag(reader, output_buffer);
+    }
+    else if (ctr_mpack_peek_type(reader) == mpack_type_nil) {
+        result = ctr_mpack_consume_nil_tag(reader);
+
+        *output_buffer = NULL;
+    }
+    else {
+        result = CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    return result;
+}
+
+int ctr_mpack_consume_binary_or_nil_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer)
+{
+    int result;
+
+    if (ctr_mpack_peek_type(reader) == mpack_type_bin) {
+        result = ctr_mpack_consume_binary_tag(reader, output_buffer);
+    }
+    else if (ctr_mpack_peek_type(reader) == mpack_type_nil) {
+        result = ctr_mpack_consume_nil_tag(reader);
+
+        *output_buffer = NULL;
+    }
+    else {
+        result = CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    return result;
+}
+
+int ctr_mpack_consume_nil_tag(mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+
+    if (NULL == reader) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_nil != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    return CTR_MPACK_SUCCESS;
+}
+
+int ctr_mpack_consume_double_tag(mpack_reader_t *reader, double *output_buffer)
+{
+    mpack_tag_t tag;
+
+    if (NULL == output_buffer) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (NULL == reader) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_double != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    *output_buffer = mpack_tag_double_value(&tag);
+
+    return CTR_MPACK_SUCCESS;
+}
+
+int ctr_mpack_consume_uint_tag(mpack_reader_t *reader, uint64_t *output_buffer)
+{
+    mpack_tag_t tag;
+
+    if (NULL == output_buffer) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (NULL == reader) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_int  != mpack_tag_type(&tag) &&
+        mpack_type_uint != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    *output_buffer = mpack_tag_uint_value(&tag);
+
+    return CTR_MPACK_SUCCESS;
+}
+
+int ctr_mpack_consume_uint32_tag(mpack_reader_t *reader, uint32_t *output_buffer)
+{
+    int      result;
+    uint64_t value;
+
+    result = ctr_mpack_consume_uint_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS) {
+        *output_buffer = (uint32_t) value;
+    }
+
+    return result;
+}
+
+int ctr_mpack_consume_uint64_tag(mpack_reader_t *reader, uint64_t *output_buffer)
+{
+    return ctr_mpack_consume_uint_tag(reader, output_buffer);
+}
+
+int ctr_mpack_consume_int_tag(mpack_reader_t *reader, int64_t *output_buffer)
+{
+    mpack_tag_t tag;
+
+    if (NULL == output_buffer) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (NULL == reader) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_int  != mpack_tag_type(&tag) &&
+        mpack_type_uint != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    *output_buffer = mpack_tag_int_value(&tag);
+
+    return CTR_MPACK_SUCCESS;
+}
+
+int ctr_mpack_consume_int32_tag(mpack_reader_t *reader, int32_t *output_buffer)
+{
+    int     result;
+    int64_t value;
+
+    result = ctr_mpack_consume_int_tag(reader, &value);
+
+    if (result == CTR_MPACK_SUCCESS) {
+        *output_buffer = (int32_t) value;
+    }
+
+    return result;
+}
+
+int ctr_mpack_consume_int64_tag(mpack_reader_t *reader, int64_t *output_buffer)
+{
+    return ctr_mpack_consume_int_tag(reader, output_buffer);
+}
+
+int ctr_mpack_consume_string_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer)
+{
+    uint32_t    string_length;
+    mpack_tag_t tag;
+
+    if (NULL == output_buffer) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (NULL == reader) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_str != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    string_length = mpack_tag_str_length(&tag);
+
+    /* This validation only applies to cmetrics and its use cases, we know
+     * for a fact that our label names and values are not supposed to be really
+     * long so a huge value here probably means that the data stream got corrupted.
+     */
+
+    if (CTR_MPACK_MAX_STRING_LENGTH < string_length) {
+        return CTR_MPACK_CORRUPT_INPUT_DATA_ERROR;
+    }
+
+    *output_buffer = cfl_sds_create_size(string_length + 1);
+
+    if (NULL == *output_buffer) {
+        return CTR_MPACK_ALLOCATION_ERROR;
+    }
+
+    cfl_sds_set_len(*output_buffer, string_length);
+
+    mpack_read_cstr(reader, *output_buffer, string_length + 1, string_length);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        cfl_sds_destroy(*output_buffer);
+
+        *output_buffer = NULL;
+
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    mpack_done_str(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        cfl_sds_destroy(*output_buffer);
+
+        *output_buffer = NULL;
+
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    return CTR_MPACK_SUCCESS;
+}
+
+int ctr_mpack_consume_binary_tag(mpack_reader_t *reader, cfl_sds_t *output_buffer)
+{
+    uint32_t    string_length;
+    mpack_tag_t tag;
+
+    if (NULL == output_buffer) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    if (NULL == reader) {
+        return CTR_MPACK_INVALID_ARGUMENT_ERROR;
+    }
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_bin != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    string_length = mpack_tag_bin_length(&tag);
+
+    *output_buffer = cfl_sds_create_size(string_length);
+
+    if (NULL == *output_buffer) {
+        return CTR_MPACK_ALLOCATION_ERROR;
+    }
+
+    cfl_sds_set_len(*output_buffer, string_length);
+
+    mpack_read_bytes(reader, *output_buffer, string_length);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        cfl_sds_destroy(*output_buffer);
+
+        *output_buffer = NULL;
+
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    mpack_done_bin(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        cfl_sds_destroy(*output_buffer);
+
+        *output_buffer = NULL;
+
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    return CTR_MPACK_SUCCESS;
+}
+
+int ctr_mpack_unpack_map(mpack_reader_t *reader,
+                         struct ctr_mpack_map_entry_callback_t *callback_list,
+                         void *context)
+{
+    struct ctr_mpack_map_entry_callback_t *callback_entry;
+    uint32_t                               entry_index;
+    uint32_t                               entry_count;
+    cfl_sds_t                              key_name;
+    int                                    result;
+    mpack_tag_t                            tag;
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader)) {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_map != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    entry_count = mpack_tag_map_count(&tag);
+
+    /* This validation only applies to cmetrics and its use cases, we know
+     * how our schema looks and how many entries the different fields have and none
+     * of those exceed the number we set CTR_MPACK_MAX_MAP_ENTRY_COUNT to which is 10.
+     * Making these sanity checks optional or configurable in runtime might be worth
+     * the itme and complexity cost but that's something I don't know at the moment.
+     */
+
+    if (CTR_MPACK_MAX_MAP_ENTRY_COUNT < entry_count) {
+        return CTR_MPACK_CORRUPT_INPUT_DATA_ERROR;
+    }
+
+    result = 0;
+
+    for (entry_index = 0 ; 0 == result && entry_index < entry_count ; entry_index++) {
+        result = ctr_mpack_consume_string_tag(reader, &key_name);
+
+        if (CTR_MPACK_SUCCESS == result) {
+            callback_entry = callback_list;
+            result = CTR_MPACK_UNEXPECTED_KEY_ERROR;
+
+            while (CTR_MPACK_UNEXPECTED_KEY_ERROR == result &&
+                   NULL != callback_entry->identifier) {
+
+                if (0 == strcmp(callback_entry->identifier, key_name)) {
+                    result = callback_entry->handler(reader, entry_index, context);
+                }
+
+                callback_entry++;
+            }
+
+            cfl_sds_destroy(key_name);
+        }
+    }
+
+    if (CTR_MPACK_SUCCESS == result) {
+        mpack_done_map(reader);
+
+        if (mpack_ok != mpack_reader_error(reader))
+        {
+            return CTR_MPACK_PENDING_MAP_ENTRIES;
+        }
+    }
+
+    return result;
+}
+
+int ctr_mpack_unpack_array(mpack_reader_t *reader,
+                           ctr_mpack_unpacker_entry_callback_fn_t entry_processor_callback,
+                           void *context)
+{
+    uint32_t              entry_index;
+    uint32_t              entry_count;
+    mpack_tag_t           tag;
+    int                   result;
+
+    tag = mpack_read_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader))
+    {
+        return CTR_MPACK_ENGINE_ERROR;
+    }
+
+    if (mpack_type_array != mpack_tag_type(&tag)) {
+        return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
+    }
+
+    entry_count = mpack_tag_array_count(&tag);
+
+    /* This validation only applies to cmetrics and its use cases, we know
+     * that in our schema we have the following arrays :
+     *     label text dictionary (strings)
+     *     dimension labels (indexes)
+     *     metric values
+     *         dimension values
+     *
+     * IMO none of these arrays should be huge so I think using 65535 as a limit
+     * gives us more than enough wiggle space (in reality I don't expect any of these
+     * arrays to hold more than 128 values but I could be wrong as that probably depends
+     * on the flush interval)
+     */
+
+    if (CTR_MPACK_MAX_ARRAY_ENTRY_COUNT < entry_count) {
+        return CTR_MPACK_CORRUPT_INPUT_DATA_ERROR;
+    }
+
+    result = CTR_MPACK_SUCCESS;
+
+    for (entry_index = 0 ;
+         CTR_MPACK_SUCCESS == result && entry_index < entry_count ;
+         entry_index++) {
+        result = entry_processor_callback(reader, entry_index, context);
+    }
+
+    if (CTR_MPACK_SUCCESS == result) {
+        mpack_done_array(reader);
+
+        if (mpack_ok != mpack_reader_error(reader))
+        {
+            return CTR_MPACK_PENDING_ARRAY_ENTRIES;
+        }
+    }
+
+    return result;
+}
+
+int ctr_mpack_peek_array_length(mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+
+    tag = mpack_peek_tag(reader);
+
+    if (mpack_ok != mpack_reader_error(reader))
+    {
+        return 0;
+    }
+
+    if (mpack_type_array != mpack_tag_type(&tag)) {
+        return 0;
+    }
+
+    return mpack_tag_array_count(&tag);
+}
+
+mpack_type_t ctr_mpack_peek_type(mpack_reader_t *reader)
+{
+    mpack_tag_t tag;
+
+    tag = mpack_peek_tag(reader);
+
+    if (mpack_reader_error(reader) != mpack_ok) {
+        return mpack_type_missing;
+    }
+
+    return mpack_tag_type(&tag);
+}

--- a/src/ctr_mpack_utils.c
+++ b/src/ctr_mpack_utils.c
@@ -125,12 +125,15 @@ int ctr_mpack_consume_uint_tag(mpack_reader_t *reader, uint64_t *output_buffer)
         return CTR_MPACK_ENGINE_ERROR;
     }
 
-    if (mpack_type_int  != mpack_tag_type(&tag) &&
-        mpack_type_uint != mpack_tag_type(&tag)) {
+    if (mpack_type_int == mpack_tag_type(&tag)) {
+        *output_buffer = (uint64_t) mpack_tag_int_value(&tag);
+    }
+    else if (mpack_type_uint == mpack_tag_type(&tag)) {
+        *output_buffer = (uint64_t) mpack_tag_uint_value(&tag);
+    }
+    else {
         return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
     }
-
-    *output_buffer = mpack_tag_uint_value(&tag);
 
     return CTR_MPACK_SUCCESS;
 }
@@ -172,12 +175,15 @@ int ctr_mpack_consume_int_tag(mpack_reader_t *reader, int64_t *output_buffer)
         return CTR_MPACK_ENGINE_ERROR;
     }
 
-    if (mpack_type_int  != mpack_tag_type(&tag) &&
-        mpack_type_uint != mpack_tag_type(&tag)) {
+    if (mpack_type_int == mpack_tag_type(&tag)) {
+        *output_buffer = (int64_t) mpack_tag_int_value(&tag);
+    }
+    else if (mpack_type_uint == mpack_tag_type(&tag)) {
+        *output_buffer = (int64_t) mpack_tag_uint_value(&tag);
+    }
+    else {
         return CTR_MPACK_UNEXPECTED_DATA_TYPE_ERROR;
     }
-
-    *output_buffer = mpack_tag_int_value(&tag);
 
     return CTR_MPACK_SUCCESS;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(UNIT_TESTS_FILES
+  decoding.c
   basic.c
   span.c
   )

--- a/tests/decoding.c
+++ b/tests/decoding.c
@@ -1,0 +1,483 @@
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
+
+/*  CMetrics
+ *  ========
+ *  Copyright 2021 Eduardo Silva <eduardo@calyptia.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+#ifdef __GNUC__
+#define _GNU_SOURCE
+#endif
+
+#include <ctraces/ctraces.h>
+#include <ctraces/ctr_encode_msgpack.h>
+#include <ctraces/ctr_decode_msgpack.h>
+#include <ctraces/ctr_encode_text.h>
+#include "ctr_tests.h"
+
+static int generate_dummy_array_attribute_set(struct cfl_array **out_array, size_t current_depth, size_t max_depth);
+static int generate_dummy_kvlist_attribute_set(struct cfl_kvlist **out_kvlist, size_t current_depth, size_t max_depth);
+
+struct cfl_kvlist *get_or_create_external_metadata_kvlist(
+    struct cfl_kvlist *root, char *key)
+{
+    struct cfl_variant *entry_variant;
+    struct cfl_kvlist  *entry_kvlist;
+    int                 result;
+
+    entry_variant = cfl_kvlist_fetch(root, key);
+
+    if (entry_variant == NULL) {
+        entry_kvlist = cfl_kvlist_create();
+
+        if (entry_kvlist == NULL) {
+            return NULL;
+        }
+
+        result = cfl_kvlist_insert_kvlist(root,
+                                          key,
+                                          entry_kvlist);
+
+        if (result != 0) {
+            cfl_kvlist_destroy(entry_kvlist);
+
+            return NULL;
+        }
+    }
+    else {
+        entry_kvlist = entry_variant->data.as_kvlist;
+    }
+
+    return entry_kvlist;
+}
+
+static int generate_dummy_array_attribute_set(struct cfl_array **out_array, size_t current_depth, size_t max_depth)
+{
+    struct cfl_array  *inner_array;
+    int                result;
+    struct cfl_kvlist *kvlist;
+    struct cfl_array  *array;
+
+    if (*out_array == NULL) {
+        array = cfl_array_create(10);
+    }
+    else {
+        array = *out_array;
+    }
+
+    if (array == NULL) {
+        return -1;
+    }
+
+    cfl_array_append_string(array, "string value");
+    cfl_array_append_bytes(array, "\xFF\xEE\xFF\xEE\xCA\xFE", 6);
+    cfl_array_append_bool(array, CTR_TRUE);
+    cfl_array_append_int64(array, 303456);
+    cfl_array_append_double(array, 1.23456);
+
+    if (current_depth < max_depth) {
+        kvlist = NULL;
+
+        result = generate_dummy_kvlist_attribute_set(&kvlist, current_depth + 1, max_depth);
+
+        if (result != 0) {
+            return -2;
+        }
+
+        result = cfl_array_append_kvlist(array, kvlist);
+
+        if (result != 0) {
+            return -3;
+        }
+
+        inner_array = NULL;
+
+        result = generate_dummy_array_attribute_set(&inner_array, current_depth + 1, max_depth);
+
+        if (result != 0) {
+            return -4;
+        }
+
+        result = cfl_array_append_array(array, inner_array);
+
+        if (result != 0) {
+            return -5;
+        }
+    }
+
+    *out_array = array;
+
+    return 0;
+}
+
+static int generate_dummy_kvlist_attribute_set(struct cfl_kvlist **out_kvlist, size_t current_depth, size_t max_depth)
+{
+    struct cfl_kvlist *inner_kvlist;
+    int                result;
+    struct cfl_kvlist *kvlist;
+    struct cfl_array  *array;
+
+    if (*out_kvlist == NULL) {
+        kvlist = cfl_kvlist_create();
+    }
+    else {
+        kvlist = *out_kvlist;
+    }
+
+    if (kvlist == NULL) {
+        return -1;
+    }
+
+    result = cfl_kvlist_insert_string(kvlist, "string value", "test value 1");
+
+    if (result != 0) {
+        return -1;
+    }
+
+
+    result = cfl_kvlist_insert_int64(kvlist, "integer value", 789);
+
+    if (result != 0) {
+        return -2;
+    }
+
+    result = cfl_kvlist_insert_double(kvlist, "double value", 0.9825);
+
+    if (result != 0) {
+        return -3;
+    }
+
+    result = cfl_kvlist_insert_bool(kvlist, "bool value", 0);
+
+    if (result != 0) {
+        return -3;
+    }
+
+    result = cfl_kvlist_insert_bytes(kvlist, "bytes value", "\xFE\xEE\xFF\xEE\xCA\xFE", 6);
+
+    if (result != 0) {
+        return -3;
+    }
+
+    if (current_depth < max_depth) {
+        array = NULL;
+
+        result = generate_dummy_array_attribute_set(&array, current_depth + 1, max_depth);
+
+        if (result != 0) {
+            return -3;
+        }
+
+        result = cfl_kvlist_insert_array(kvlist, "array value", array);
+
+        if (result != 0) {
+            return -3;
+        }
+
+        inner_kvlist = NULL;
+
+        result = generate_dummy_kvlist_attribute_set(&inner_kvlist, current_depth + 1, max_depth);
+
+        if (result != 0) {
+            return -3;
+        }
+
+        result = cfl_kvlist_insert_kvlist(kvlist, "kvlist value", inner_kvlist);
+
+        if (result != 0) {
+            return -3;
+        }
+    }
+
+    *out_kvlist = kvlist;
+
+    return 0;
+}
+
+static int generate_sample_resource_attributes(struct ctrace_resource *resource)
+{
+    struct ctrace_attributes *attributes;
+    int                       result;
+
+    attributes = ctr_attributes_create();
+
+    if (attributes == NULL) {
+        return -1;
+    }
+
+    result = generate_dummy_kvlist_attribute_set(&attributes->kv, 0, 2);
+
+    if (result != 0) {
+        ctr_attributes_destroy(attributes);
+
+        return -2;
+    }
+
+    result = ctr_resource_set_attributes(resource, attributes);
+
+    if (result != 0) {
+        ctr_attributes_destroy(attributes);
+
+        return -3;
+    }
+
+    return 0;
+}
+
+static int generate_sample_link_attributes(struct ctrace_link *link)
+{
+    struct ctrace_attributes *attributes;
+    int                       result;
+
+    attributes = ctr_attributes_create();
+
+    if (attributes == NULL) {
+        return -1;
+    }
+
+    result = generate_dummy_kvlist_attribute_set(&attributes->kv, 0, 2);
+
+    if (result != 0) {
+        ctr_attributes_destroy(attributes);
+
+        return -2;
+    }
+
+    result = ctr_link_set_attributes(link, attributes);
+
+    if (result != 0) {
+        ctr_attributes_destroy(attributes);
+
+        return -3;
+    }
+
+    return 0;
+}
+
+int generate_sample_instrumentation_scope(struct ctrace_scope_span *scope_span)
+{
+    struct ctrace_instrumentation_scope *instrumentation_scope;
+    struct ctrace_attributes            *attributes;
+    int                                  result;
+
+    attributes = ctr_attributes_create();
+
+    if (attributes == NULL) {
+        return -1;
+    }
+
+    result = generate_dummy_kvlist_attribute_set(&attributes->kv, 0, 2);
+
+    if (result != 0) {
+        ctr_attributes_destroy(attributes);
+
+        return -2;
+    }
+
+    instrumentation_scope = ctr_instrumentation_scope_create("sample instrumentation scope",
+                                                             "0.0.1",
+                                                             123,
+                                                             attributes);
+
+    if (instrumentation_scope == NULL) {
+        ctr_attributes_destroy(attributes);
+
+        return -3;
+    }
+
+    ctr_scope_span_set_instrumentation_scope(scope_span, instrumentation_scope);
+
+    return 0;
+}
+
+
+
+static struct ctrace *generate_encoder_test_data()
+{
+    struct ctrace_resource_span *resource_span;
+    struct ctrace_scope_span    *scope_span;
+    struct ctrace               *context;
+    int                          result;
+    struct ctrace_span_event    *event;
+    struct ctrace_span          *span;
+    struct ctrace_link          *link;
+
+    context = ctr_create(NULL);
+
+    if (context == NULL) {
+        return NULL;
+    }
+
+    resource_span = ctr_resource_span_create(context);
+
+    if (resource_span == NULL) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    ctr_resource_span_set_schema_url(resource_span, "http://resource_1.schema.url:9999/spec.json");
+    ctr_resource_set_dropped_attr_count(resource_span->resource, 123);
+
+    result = generate_sample_resource_attributes(resource_span->resource);
+
+    if (result != 0) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    scope_span = ctr_scope_span_create(resource_span);
+
+    if (scope_span == NULL) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    ctr_scope_span_set_schema_url(scope_span, "http://scope_span_1.schema.url:8888/spec.json");
+
+    result = generate_sample_instrumentation_scope(scope_span);
+
+    if (result != 0) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    span = ctr_span_create(context, scope_span, "sample span 1", NULL);
+
+    if (span == NULL) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    ctr_span_set_status(span, CTRACE_SPAN_STATUS_CODE_OK, "TEST STATE 1");
+    ctr_span_set_trace_id(span, "CTR_TRACE_000001", 16);
+    ctr_span_set_span_id(span, "SPAN_001", 8);
+    ctr_span_set_parent_span_id(span, "SPAN_801", 8);
+    ctr_span_kind_set(span, CTRACE_SPAN_INTERNAL);
+    ctr_span_start_ts(context, span, 1000000);
+    ctr_span_end_ts(context, span, 2000000);
+
+    result = generate_dummy_kvlist_attribute_set(&span->attr->kv, 0, 2);
+
+    if (result != 0) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    ctr_span_set_dropped_events_count(span, 555);
+
+    event = ctr_span_event_add_ts(span, "span_1_event_1", 0x7357);
+
+    if (event == NULL) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    ctr_span_event_set_dropped_attributes_count(event, 999);
+
+    result = generate_dummy_kvlist_attribute_set(&event->attr->kv, 0, 2);
+
+    if (result != 0) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    // ctr_span_event_set_attribute_string(event, "event_attribute_1", "TEST STRING attribute value");
+    // ctr_span_event_set_attribute_int(event,  "event_attribute_2", 987);
+    // ctr_span_event_set_attribute_double(event, "event_attribute_2", 9.21);
+    ctr_span_event_set_dropped_attributes_count(event, 888);
+
+    link = ctr_link_create(span,
+                           "CTR_TRACE_800000", 16,
+                           "SPAN_801", 8);
+
+    if (link == NULL) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    ctr_link_set_trace_state(link, "TEST STATE 2");
+    ctr_link_set_dropped_attr_count(link, 987);
+
+    result = generate_sample_link_attributes(link);
+
+    if (result != 0) {
+        ctr_destroy(context);
+
+        return NULL;
+    }
+
+    return context;
+}
+
+/*
+ * perform the following and then compare text buffers
+ *
+ * CMT +-> MSGPACK -> CMT -> TEXT
+ *     +-> TEXT                |
+ *          |                  |
+ *          |---> compare <----|
+ */
+
+void test_msgpack_to_cmt()
+{
+    char          *validation_text_buffer;
+    char          *referece_text_buffer;
+    char          *msgpack_text_buffer;
+    size_t         msgpack_text_size;
+    struct ctrace *decoded_context;
+    struct ctrace *context;
+    size_t         offset;
+    int            result;
+
+    offset = 0;
+
+    context = generate_encoder_test_data();
+    TEST_ASSERT(context != NULL);
+
+    referece_text_buffer = ctr_encode_text_create(context);
+    TEST_ASSERT(referece_text_buffer != NULL);
+
+    result = ctr_encode_msgpack_create(context, &msgpack_text_buffer, &msgpack_text_size);
+    TEST_ASSERT(result == 0);
+
+    result = ctr_decode_msgpack_create(&decoded_context, msgpack_text_buffer, msgpack_text_size, &offset);
+    TEST_ASSERT(result == 0);
+
+    validation_text_buffer = ctr_encode_text_create(context);
+    TEST_ASSERT(validation_text_buffer != NULL);
+
+    TEST_ASSERT(strcmp(referece_text_buffer, validation_text_buffer) == 0);
+
+    ctr_encode_msgpack_destroy(msgpack_text_buffer);
+    ctr_encode_text_destroy(validation_text_buffer);
+    ctr_encode_text_destroy(referece_text_buffer);
+
+    ctr_destroy(decoded_context);
+    ctr_destroy(context);
+}
+
+
+TEST_LIST = {
+    {"cmt_msgpack",      test_msgpack_to_cmt},
+    { 0 }
+};


### PR DESCRIPTION
This PR adds a msgpack decoder and its accompanying test case as well as some dependencies and fixes.

These dependencies will be moved to a neutral place in the near future and the decoder and the decoder will probably be refactored to make it linear to simplify the code.

```
==188765== Memcheck, a memory error detector
==188765== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==188765== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==188765== Command: ./tests/ctr-test-decoding
==188765== 
Test cmt_msgpack...                             [ OK ]
SUCCESS: All unit tests have passed.
==188765== 
==188765== HEAP SUMMARY:
==188765==     in use at exit: 0 bytes in 0 blocks
==188765==   total heap usage: 2,152 allocs, 2,152 frees, 4,530,407 bytes allocated
==188765== 
==188765== All heap blocks were freed -- no leaks are possible
==188765== 
==188765== For lists of detected and suppressed errors, rerun with: -s
==188765== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```