### PR TITLE
msgpack: changed the id encoding mechanism used for msgpack

### DIFF
--- a/include/ctraces/ctr_id.h
+++ b/include/ctraces/ctr_id.h
@@ -39,5 +39,6 @@ int ctr_id_cmp(struct ctrace_id *cid1, struct ctrace_id *cid2);
 size_t ctr_id_get_len(struct ctrace_id *cid);
 void *ctr_id_get_buf(struct ctrace_id *cid);
 cfl_sds_t ctr_id_to_lower_base16(struct ctrace_id *cid);
+struct ctrace_id *ctr_id_from_base16(cfl_sds_t id);
 
 #endif

--- a/src/ctr_encode_msgpack.c
+++ b/src/ctr_encode_msgpack.c
@@ -175,8 +175,24 @@ static void pack_instrumentation_scope(mpack_writer_t *writer, struct ctrace_ins
 
 static void pack_id(mpack_writer_t *writer, struct ctrace_id *id)
 {
+    cfl_sds_t encoded_id;
+
+
     if (id) {
-        mpack_write_bin(writer, id->buf, cfl_sds_len(id->buf));
+        encoded_id = ctr_id_to_lower_base16(id);
+
+        if (encoded_id != NULL) {
+            mpack_write_cstr(writer, encoded_id);
+
+            cfl_sds_destroy(encoded_id);
+        }
+        else {
+            /* we should be able to report this but at the moment
+             * we are not.
+             */
+
+            mpack_write_nil(writer);
+        }
     }
     else {
         mpack_write_nil(writer);

--- a/src/ctr_id.c
+++ b/src/ctr_id.c
@@ -242,11 +242,12 @@ struct ctrace_id *ctr_id_from_base16(cfl_sds_t id)
         input_index++;
     }
 
-    if (!result) {
-        return NULL;
+    if (result) {
+        result_id = ctr_id_create(decoded_id, length / 2);
     }
-
-    result_id = ctr_id_create(decoded_id, length / 2);
+    else {
+        result_id = NULL;
+    }
 
     cfl_sds_destroy(decoded_id);
 

--- a/src/ctr_id.c
+++ b/src/ctr_id.c
@@ -151,3 +151,104 @@ cfl_sds_t ctr_id_to_lower_base16(struct ctrace_id *cid)
 
     return out;
 }
+
+/* This function returns CFL_TRUE on success and CFL_FALSE on
+ * failure.
+ */
+static int decode_hex_digit(char *digit)
+{
+    if (*digit >= '0' && *digit <= '9') {
+        *digit -= '0';
+    }
+    else if (*digit >= 'a' && *digit <= 'f') {
+        *digit -= 'a';
+        *digit += 10;
+    }
+    else if (*digit >= 'A' && *digit <= 'F') {
+        *digit -= 'A';
+        *digit += 10;
+    }
+    else {
+        return CFL_FALSE;
+    }
+
+    return CFL_TRUE;
+}
+
+struct ctrace_id *ctr_id_from_base16(cfl_sds_t id)
+{
+    size_t            output_index;
+    size_t            input_index;
+    cfl_sds_t         decoded_id;
+    struct ctrace_id *result_id;
+    int               result;
+    size_t            length;
+    char              digit;
+    char              value;
+
+    if (id == NULL) {
+        return NULL;
+    }
+
+    length = cfl_sds_len(id);
+
+    if (length < 2) {
+        return NULL;
+    }
+
+    if ((length % 2) != 0) {
+        return NULL;
+    }
+
+    decoded_id = cfl_sds_create_size(length / 2);
+
+    if (decoded_id == NULL) {
+        return NULL;
+    }
+
+    output_index = 0;
+    input_index = 0;
+    value = 0;
+
+    /* This loop consumes one character per iteration,
+     * on each iteration it verifies that the character
+     * corresponds to the base16 charset and then
+     * it subtracts the correct base to get a number
+     * ranging from 0 to 16.
+     * Then the accumulator is left shifted 4 bits and
+     * the current value is bitwise ORed to its value.
+     * If the character index is odd then the accumulator
+     * value is appended to the decoded id buffer and
+     * reinitialized to be used on the next iteration.
+    */
+
+    while (input_index < length) {
+        digit = id[input_index];
+        result = decode_hex_digit(&digit);
+
+        if (!result) {
+            break;
+        }
+
+        digit  &= 0xF;
+        value <<= 4;
+        value  |= digit;
+
+        if ((input_index % 2) == 1) {
+            decoded_id[output_index++] = value;
+            value = 0;
+        }
+
+        input_index++;
+    }
+
+    if (!result) {
+        return NULL;
+    }
+
+    result_id = ctr_id_create(decoded_id, length / 2);
+
+    cfl_sds_destroy(decoded_id);
+
+    return result_id;
+}


### PR DESCRIPTION
id: added a function to create a ctrace_id from a base16 encoded string msgpack: changed the encode mechanism for all the id fields so instead of encoding them as binary chunks they are encoded as base16 string which is how the OTLP json - protobuf mapping works.

Signed-off-by: Leonardo Alminana <leonardo@calyptia.com>