### PR TITLE
build: bump to v0.3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 # CTraces Version
 set(CTR_VERSION_MAJOR  0)
 set(CTR_VERSION_MINOR  3)
-set(CTR_VERSION_PATCH  0)
+set(CTR_VERSION_PATCH  1)
 set(CTR_VERSION_STR "${CTR_VERSION_MAJOR}.${CTR_VERSION_MINOR}.${CTR_VERSION_PATCH}")
 
 # Define __FILENAME__ consistently across Operating Systems

--- a/include/ctraces/ctr_mpack_utils_defs.h
+++ b/include/ctraces/ctr_mpack_utils_defs.h
@@ -34,7 +34,7 @@
 #define CTR_MPACK_ERROR_CUTOFF               20
 
 #define CTR_MPACK_MAX_ARRAY_ENTRY_COUNT      65535
-#define CTR_MPACK_MAX_MAP_ENTRY_COUNT        20
-#define CTR_MPACK_MAX_STRING_LENGTH          1024
+#define CTR_MPACK_MAX_MAP_ENTRY_COUNT        512
+#define CTR_MPACK_MAX_STRING_LENGTH          (1024 * 1000)
 
 #endif


### PR DESCRIPTION
utils: update `CTR_MPACK_MAX_MAP_ENTRY_COUNT` and `CTR_MPACK_MAX_STRING_LENGTH`
build: bump to v0.3.1