### PR TITLE
encode_msgpack: Fix null-dereference

### DIFF
--- a/src/ctr_encode_msgpack.c
+++ b/src/ctr_encode_msgpack.c
@@ -418,7 +418,12 @@ static void pack_scope_spans(mpack_writer_t *writer, struct cfl_list *scope_span
 
         /* scope */
         mpack_write_cstr(writer, "scope");
-        pack_instrumentation_scope(writer, scope_span->instrumentation_scope);
+        if (scope_span->instrumentation_scope != NULL) {
+            pack_instrumentation_scope(writer, scope_span->instrumentation_scope);
+        }
+        else {
+            mpack_write_nil(writer);
+        }
 
         /* spans */
         mpack_write_cstr(writer, "spans");


### PR DESCRIPTION
Fixes: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62368