### PR TITLE
opentelemetry: fixed scope member handling

### DIFF
--- a/src/ctr_decode_msgpack.c
+++ b/src/ctr_decode_msgpack.c
@@ -137,7 +137,8 @@ static int unpack_instrumentation_scope_attributes(mpack_reader_t *reader, size_
 
 static int unpack_scope_span_instrumentation_scope(mpack_reader_t *reader, size_t index, void *ctx)
 {
-    int result;
+    mpack_type_t                          tag_type;
+    int                                   result;
     struct ctrace_instrumentation_scope  *instrumentation_scope;
     struct ctr_msgpack_decode_context    *context = ctx;
     struct ctr_mpack_map_entry_callback_t callbacks[] = \
@@ -149,6 +150,12 @@ static int unpack_scope_span_instrumentation_scope(mpack_reader_t *reader, size_
             {NULL,                       NULL}
         };
 
+    tag_type = ctr_mpack_peek_type(reader);
+
+    if (tag_type == mpack_type_nil) {
+        return ctr_mpack_consume_nil_tag(reader);
+    }
+
     instrumentation_scope = ctr_instrumentation_scope_create(NULL, NULL, 0, NULL);
 
     if (instrumentation_scope == NULL) {
@@ -158,10 +165,12 @@ static int unpack_scope_span_instrumentation_scope(mpack_reader_t *reader, size_
     ctr_scope_span_set_instrumentation_scope(context->scope_span, instrumentation_scope);
 
     result = ctr_mpack_unpack_map(reader, callbacks, ctx);
+
     if (result != CTR_DECODE_MSGPACK_SUCCESS) {
         ctr_instrumentation_scope_destroy(context->scope_span->instrumentation_scope);
         context->scope_span->instrumentation_scope = NULL;
     }
+
     return result;
 }
 

--- a/src/ctr_decode_opentelemetry.c
+++ b/src/ctr_decode_opentelemetry.c
@@ -552,7 +552,10 @@ int ctr_decode_opentelemetry_create(struct ctrace **out_ctr,
 
             scope_span = ctr_scope_span_create(resource_span);
             ctr_scope_span_set_schema_url(scope_span, otel_scope_span->schema_url);
-            ctr_scope_span_set_scope(scope_span, otel_scope_span->scope);
+
+            if (otel_scope_span->scope != NULL) {
+                ctr_scope_span_set_scope(scope_span, otel_scope_span->scope);
+            }
 
             for (span_index = 0; span_index < otel_scope_span->n_spans; span_index++) {
                 otel_span = otel_scope_span->spans[span_index];

--- a/src/ctr_encode_msgpack.c
+++ b/src/ctr_encode_msgpack.c
@@ -136,6 +136,12 @@ static void pack_attributes(mpack_writer_t *writer, struct ctrace_attributes *at
 
 static void pack_instrumentation_scope(mpack_writer_t *writer, struct ctrace_instrumentation_scope *ins_scope)
 {
+    if (ins_scope == NULL) {
+        mpack_write_nil(writer);
+        
+        return;
+    }
+
     mpack_start_map(writer, 4);
 
     /* name */


### PR DESCRIPTION
This PR makes the scope field of the scope span structure optional as expected.