### PR TITLE
variant_utils: Set the variant size on strings/bytes

### DIFF
--- a/include/ctraces/ctr_variant_utils.h
+++ b/include/ctraces/ctr_variant_utils.h
@@ -420,6 +420,7 @@ static inline int unpack_cfl_variant_string(mpack_reader_t *reader,
     }
 
     (*value)->type = CFL_VARIANT_STRING;
+    (*value)->size = value_length;
 
     return 0;
 }
@@ -465,6 +466,7 @@ static inline int unpack_cfl_variant_binary(mpack_reader_t *reader,
     }
 
     (*value)->type = CFL_VARIANT_BYTES;
+    (*value)->size = value_length;
 
     return 0;
 }


### PR DESCRIPTION
Since https://github.com/fluent/fluent-bit/commit/1ce8d04598, any code that needs to read a variant string/bytes size must use the `cfl_variant_size_get` function because variant strings might be references.

Ctraces must also set that field or else it is not possible to determine the length.