### PR TITLE
encode_opentelemetry: Handle minimal otel payloads

### DIFF
--- a/src/ctr_encode_opentelemetry.c
+++ b/src/ctr_encode_opentelemetry.c
@@ -917,11 +917,21 @@ static Opentelemetry__Proto__Common__V1__InstrumentationScope *set_instrumentati
         return NULL;
     }
 
-    otel_scope->name = instrumentation_scope->name;
-    otel_scope->version = instrumentation_scope->version;
+    if (instrumentation_scope->name) {
+        otel_scope->name = instrumentation_scope->name;
+    }
+    else {
+        otel_scope->name = "";
+    }
+    if (instrumentation_scope->version) {
+        otel_scope->version = instrumentation_scope->version;
+    }
+    else {
+        otel_scope->version = "";
+    }
     otel_scope->n_attributes = get_attributes_count(instrumentation_scope->attr);
     otel_scope->dropped_attributes_count = instrumentation_scope->dropped_attr_count;
-    otel_scope->attributes = set_attributes_from_ctr(instrumentation_scope->attr);;
+    otel_scope->attributes = set_attributes_from_ctr(instrumentation_scope->attr);
 
     return otel_scope;
 }
@@ -989,7 +999,9 @@ static Opentelemetry__Proto__Trace__V1__ScopeSpans **set_scope_spans(struct ctra
         }
 
         otel_scope_span->schema_url = scope_span->schema_url;
-        otel_scope_span->scope = set_instrumentation_scope(scope_span->instrumentation_scope);
+        if (scope_span->instrumentation_scope != NULL) {
+            otel_scope_span->scope = set_instrumentation_scope(scope_span->instrumentation_scope);
+        }
 
         span_count = cfl_list_size(&scope_span->spans);
         otel_scope_span->n_spans = span_count;


### PR DESCRIPTION
In some circumstances, instrumentation scope is happened to be NULL:

```
fluent-bit        | #0  0x59a1f7596740      in  set_instrumentation_scope() at lib/ctraces/src/ctr_encode_opentelemetry.c:917
fluent-bit        | #1  0x59a1f75968f3      in  set_scope_spans() at lib/ctraces/src/ctr_encode_opentelemetry.c:983
fluent-bit        | #2  0x59a1f7596ae4      in  set_resource_spans() at lib/ctraces/src/ctr_encode_opentelemetry.c:1051
fluent-bit        | #3  0x59a1f7596beb      in  create_export_service_request() at lib/ctraces/src/ctr_encode_opentelemetry.c:1087
fluent-bit        | #4  0x59a1f7597300      in  ctr_encode_opentelemetry_create() at lib/ctraces/src/ctr_encode_opentelemetry.c:1304
fluent-bit        | #5  0x59a1f737cd3d      in  process_traces() at plugins/out_opentelemetry/opentelemetry.c:389
fluent-bit        | #6  0x59a1f737d3e0      in  cb_opentelemetry_flush() at plugins/out_opentelemetry/opentelemetry.c:485
fluent-bit        | #7  0x59a1f6e5dfc3      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:598
fluent-bit        | #8  0x59a1f7b59a86      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
fluent-bit        | #9  0xffffffffffffffff  in  ???() at ???:0
```

With the reproducible steps here: https://github.com/fluent/fluent-bit/issues/9391

In this PR, Plug an occurrence of SEGV due to empty spans.

In unit tests, I created the similar circumstances that handles the empty spans:

```
|-------------------- RESOURCE SPAN --------------------|
  resource:
     - attributes:
            - receiver.tool: 'ctraces'
     - dropped_attributes_count: 0
  schema_url: 
  [scope_span]
    schema_url: 
    [spans]
```

Additional context:

Under the current ctraces, I still got a SEGV error:

```
fluent-bit        | #0  0x597458c257b8      in  set_instrumentation_scope() at lib/ctraces/src/ctr_encode_opentelemetry.c:920
fluent-bit        | #1  0x597458c259d0      in  set_scope_spans() at lib/ctraces/src/ctr_encode_opentelemetry.c:1003
fluent-bit        | #2  0x597458c25bc1      in  set_resource_spans() at lib/ctraces/src/ctr_encode_opentelemetry.c:1072
fluent-bit        | #3  0x597458c25cc8      in  create_export_service_request() at lib/ctraces/src/ctr_encode_opentelemetry.c:1108
fluent-bit        | #4  0x597458c263dd      in  ctr_encode_opentelemetry_create() at lib/ctraces/src/ctr_encode_opentelemetry.c:1325
fluent-bit        | #5  0x597458a0bd3d      in  process_traces() at plugins/out_opentelemetry/opentelemetry.c:389
fluent-bit        | #6  0x597458a0c3e0      in  cb_opentelemetry_flush() at plugins/out_opentelemetry/opentelemetry.c:485
fluent-bit        | #7  0x5974584ecfc3      in  output_pre_cb_flush() at include/fluent-bit/flb_output.h:598
fluent-bit        | #8  0x5974591e8d86      in  co_init() at lib/monkey/deps/flb_libco/amd64.c:117
fluent-bit        | #9  0xffffffffffffffff  in  ???() at ???:0
```
